### PR TITLE
Resolve peer dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ A Prettier plugin that wraps verbose class name based on the `printWidth` option
 
 ## Installation
 
-```sh
-npm install -D prettier prettier-plugin-classnames
-```
+For Prettier v2:
 
 ```sh
-yarn add -D prettier prettier-plugin-classnames
+npm install -D prettier@^2 prettier-plugin-classnames
 ```
 
+For Prettier v3:
+
 ```sh
-pnpm add -D prettier prettier-plugin-classnames
+npm install -D prettier prettier-plugin-classnames @prettier/sync
 ```
 
 ## Configuration

--- a/package.json
+++ b/package.json
@@ -22,10 +22,8 @@
     "test:v2": "cross-env NODE_OPTIONS=--experimental-vm-modules PRETTIER_VERSION=2 jest --ci --passWithNoTests",
     "test:v3": "cross-env NODE_OPTIONS=--experimental-vm-modules PRETTIER_VERSION=3 jest --ci --passWithNoTests"
   },
-  "dependencies": {
-    "@prettier/sync": "0.3.0"
-  },
   "devDependencies": {
+    "@prettier/sync": "0.3.0",
     "@trivago/prettier-plugin-sort-imports": "4.1.1",
     "@types/jest": "29.5.2",
     "@types/node": "20.2.5",
@@ -47,7 +45,13 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
+    "@prettier/sync": "0.3.0",
     "prettier": "~2.8.4 || ~3.0.3"
+  },
+  "peerDependenciesMeta": {
+    "@prettier/sync": {
+      "optional": true
+    }
   },
   "optionalDependencies": {
     "classnames": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@prettier/sync": "0.3.0",
-    "prettier": "~2.8.4 || ~3.0.3"
+    "@prettier/sync": "^0.3.0",
+    "prettier": "^2 || ^3"
   },
   "peerDependenciesMeta": {
     "@prettier/sync": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "prettier": "~2.8.4 || ~3.0.3"
   },
   "optionalDependencies": {
-    "classnames": "2.3.2",
-    "prettier-plugin-merge": "~0.2.0"
+    "classnames": "2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-import-resolver-typescript": "3.5.3",
     "eslint-plugin-import": "2.27.5",
     "jest": "29.5.0",
-    "prettier": "~2.8.4",
+    "prettier": "2.8.4",
     "prettier3": "npm:prettier@3.0.3",
     "ts-jest": "29.1.0",
     "typescript": "4.9.5"

--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "@prettier/sync": {
       "optional": true
     }
-  },
-  "optionalDependencies": {
-    "classnames": "2.3.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ specifiers:
   eslint-import-resolver-typescript: 3.5.3
   eslint-plugin-import: 2.27.5
   jest: 29.5.0
-  prettier: ~2.8.4
+  prettier: 2.8.4
   prettier3: npm:prettier@3.0.3
   ts-jest: 29.1.0
   typescript: 4.9.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ specifiers:
   '@types/node': 20.2.5
   '@typescript-eslint/eslint-plugin': 5.54.0
   '@typescript-eslint/parser': 5.54.0
-  classnames: 2.3.2
   cross-env: 7.0.3
   esbuild: 0.17.19
   eslint: 8.35.0
@@ -22,9 +21,6 @@ specifiers:
   prettier3: npm:prettier@3.0.3
   ts-jest: 29.1.0
   typescript: 4.9.5
-
-optionalDependencies:
-  classnames: 2.3.2
 
 devDependencies:
   '@prettier/sync': 0.3.0_prettier@3.0.3
@@ -1541,12 +1537,6 @@ packages:
   /cjs-module-lexer/1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: true
-
-  /classnames/2.3.2:
-    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /cliui/8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ specifiers:
   eslint-plugin-import: 2.27.5
   jest: 29.5.0
   prettier: ~2.8.4
-  prettier-plugin-merge: ~0.2.0
   prettier3: npm:prettier@3.0.3
   ts-jest: 29.1.0
   typescript: 4.9.5
@@ -29,7 +28,6 @@ dependencies:
 
 optionalDependencies:
   classnames: 2.3.2
-  prettier-plugin-merge: 0.2.0_prettier@3.0.3
 
 devDependencies:
   '@trivago/prettier-plugin-sort-imports': 4.1.1_prettier@3.0.3
@@ -1700,12 +1698,6 @@ packages:
     resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
-
-  /diff/5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
-    engines: {node: '>=0.3.1'}
-    dev: false
-    optional: true
 
   /dir-glob/3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3542,17 +3534,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
     dev: true
-
-  /prettier-plugin-merge/0.2.0_prettier@3.0.3:
-    resolution: {integrity: sha512-2iStjZCMlmBXoGstBcBYXHcNhmafSL/pwJd4mWAQVTOGXPWo1UJ77wuI22vpVgla8Pkgbn62UA51d/rBsxAwrg==}
-    requiresBuild: true
-    peerDependencies:
-      prettier: ~2.8.4
-    dependencies:
-      diff: 5.1.0
-      prettier: 3.0.3
-    dev: false
-    optional: true
 
   /prettier/2.8.4:
     resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,13 +23,11 @@ specifiers:
   ts-jest: 29.1.0
   typescript: 4.9.5
 
-dependencies:
-  '@prettier/sync': 0.3.0_prettier@3.0.3
-
 optionalDependencies:
   classnames: 2.3.2
 
 devDependencies:
+  '@prettier/sync': 0.3.0_prettier@3.0.3
   '@trivago/prettier-plugin-sort-imports': 4.1.1_prettier@3.0.3
   '@types/jest': 29.5.2
   '@types/node': 20.2.5
@@ -970,7 +968,7 @@ packages:
       prettier: ^3.0.0
     dependencies:
       prettier: 3.0.3
-    dev: false
+    dev: true
 
   /@sinclair/typebox/0.25.24:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -3545,6 +3543,7 @@ packages:
     resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /pretty-format/29.5.0:
     resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}


### PR DESCRIPTION
Prettier v3 users must now explicitly install the `@prettier/sync` dependency.