### PR TITLE
Improve code readability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,10 @@ importers:
       typescript: 4.9.5
 
   src/packages/core-parts:
-    specifiers: {}
+    specifiers:
+      zod: 3.22.4
+    dependencies:
+      zod: 3.22.4
 
   src/packages/v2-plugin:
     specifiers:
@@ -2607,3 +2610,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod/3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/packages/core-parts/package.json
+++ b/src/packages/core-parts/package.json
@@ -3,5 +3,8 @@
   "name": "core-parts",
   "version": "0.0.0",
   "author": "Hyeonjong <nianelo4@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "zod": "3.22.4"
+  }
 }


### PR DESCRIPTION
Type checking of objects now uses the [zod](https://zod.dev/) library instead of raw code.

This change increases the size of the bundle, but makes the code more maintainable.