### PR TITLE
Applies extra indentation when line breaks occur in class names in ternary operators

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,5 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": ["olat", "slbp", "tlbp"]
+  "words": ["olat", "slbp", "slto", "tlbp", "tlto"]
 }


### PR DESCRIPTION
Example of formatting results (before PR)

```javascript
export function Callout({ children }) {
  return (
    <div
      className={
        condition
          ? `bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
          dark:border-neutral-500/30 px-4 py-4 rounded-xl`
          : `rounded-xl py-4 px-4 dark:border-neutral-500/30 dark:bg-neutral-900/50
          border-zinc-400/30 border bg-gray-100/50`
      }
    >
      {children}
    </div>
  );
}
```

Example of formatting results (after PR)

```javascript
export function Callout({ children }) {
  return (
    <div
      className={
        condition
          ? `bg-gray-100/50 border border-zinc-400/30 dark:bg-neutral-900/50
            dark:border-neutral-500/30 px-4 py-4 rounded-xl`
          : `rounded-xl py-4 px-4 dark:border-neutral-500/30 dark:bg-neutral-900/50
            border-zinc-400/30 border bg-gray-100/50`
      }
    >
      {children}
    </div>
  );
}
```