### PR TITLE
Add new option `endingPosition`

### DIFF
--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -65,4 +65,5 @@ export type NarrowedParserOptions = {
   parser: string;
   customAttributes: string[];
   customFunctions: string[];
+  endingPosition: 'relative' | 'absolute';
 };

--- a/src/packages/v2-plugin/options.ts
+++ b/src/packages/v2-plugin/options.ts
@@ -19,4 +19,21 @@ export const options: SupportOptions = {
     description:
       'List of functions that enclosing class names. The `classNames` function is always supported, even if no options are specified.',
   },
+  endingPosition: {
+    since: '0.5.0',
+    type: 'choice',
+    category: 'Format',
+    default: 'relative',
+    description: 'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
+    choices: [
+      {
+        value: 'relative',
+        description: 'Each line ends at a `printWidth` distance from the start of the class name.',
+      },
+      {
+        value: 'absolute',
+        description: 'Each line ends at a `printWidth` distance from the start of the line.',
+      },
+    ]
+  },
 };

--- a/src/packages/v2-plugin/options.ts
+++ b/src/packages/v2-plugin/options.ts
@@ -24,7 +24,8 @@ export const options: SupportOptions = {
     type: 'choice',
     category: 'Format',
     default: 'relative',
-    description: 'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
+    description:
+      'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
     choices: [
       {
         value: 'relative',
@@ -34,6 +35,6 @@ export const options: SupportOptions = {
         value: 'absolute',
         description: 'Each line ends at a `printWidth` distance from the start of the line.',
       },
-    ]
+    ],
   },
 };

--- a/src/packages/v3-plugin/options.ts
+++ b/src/packages/v3-plugin/options.ts
@@ -21,4 +21,22 @@ export const options: SupportOptions = {
     description:
       'List of functions that enclosing class names. The `classNames` function is always supported, even if no options are specified.',
   },
+  endingPosition: {
+    // @ts-ignore
+    since: '0.5.0',
+    type: 'choice',
+    category: 'Format',
+    default: 'relative',
+    description: 'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
+    choices: [
+      {
+        value: 'relative',
+        description: 'Each line ends at a `printWidth` distance from the start of the class name.',
+      },
+      {
+        value: 'absolute',
+        description: 'Each line ends at a `printWidth` distance from the start of the line.',
+      },
+    ]
+  },
 };

--- a/src/packages/v3-plugin/options.ts
+++ b/src/packages/v3-plugin/options.ts
@@ -27,7 +27,8 @@ export const options: SupportOptions = {
     type: 'choice',
     category: 'Format',
     default: 'relative',
-    description: 'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
+    description:
+      'This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.',
     choices: [
       {
         value: 'relative',
@@ -37,6 +38,6 @@ export const options: SupportOptions = {
         value: 'absolute',
         description: 'Each line ends at a `printWidth` distance from the start of the line.',
       },
-    ]
+    ],
   },
 };


### PR DESCRIPTION
This PR closes #21.

## What option is this?

This is the criterion for ending the class name on each line when replacing the original class name with a multi-line class name.

As you can also see in the [README](https://github.com/ony3000/prettier-plugin-classnames/tree/v0.4.0#criterion-for-printwidth), the formatting results in the current version may slightly overflow the `printWidth` of the Prettier config.

According to the Prettier documentation, the `printWidth` option is different from ESLint's `max-len`, so strict line wrapping may not be necessary. However, since the original purpose of this plugin (and probably the purpose of most users of this plugin) was to wrap verbose tailwindcss class names, the need for strict line wrapping is somewhat natural.

## What options are available?

### `relative`

Use the current criterion as is. This is the default option for backward compatibility reasons.

Example output:

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
                |--------------------------------------------------|
      className="bg-gray-100/50 border border-zinc-400/30
       |--------------------------------------------------|
        dark:bg-neutral-900/50 dark:border-neutral-500/30
        px-4 py-4 rounded-xl"
    >
      {children}
    </div>
  );
}
```

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
      className={classNames(
        |--------------------------------------------------|
        `bg-gray-100/50 border border-zinc-400/30
       |--------------------------------------------------|
        dark:bg-neutral-900/50 dark:border-neutral-500/30
        px-4 py-4 rounded-xl`,
      )}
    >
      {children}
    </div>
  );
}
```

### `absolute`

Strictly enforces `printWidth` on each line of a multiline class name.

Example output:

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
      className="bg-gray-100/50 border
border-zinc-400/30 dark:bg-neutral-900/50
dark:border-neutral-500/30 px-4 py-4 rounded-xl"
    >
      {children}
    </div>
  );
}
```

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
      className={classNames(
        `bg-gray-100/50 border border-zinc-400/30
dark:bg-neutral-900/50 dark:border-neutral-500/30
px-4 py-4 rounded-xl`,
      )}
    >
      {children}
    </div>
  );
}
```