### PR TITLE
Adds `absolute-with-indent`, which can be selected as an option to `endingPosition`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,5 @@
 {
   "version": "0.2",
   "language": "en",
-  "words": ["slsl", "slto", "tlop", "tlto", "tlpq", "quasis", "astro"]
+  "words": ["slsl", "slto", "tlsl", "tlop", "tlto", "tlpq", "quasis", "astro"]
 }

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -209,22 +209,40 @@ export function findTargetClassNameNodes(
       case 'JSXExpressionContainer': {
         nonCommentNodes.push(currentASTNode);
 
-        classNameNodes.forEach((classNameNode) => {
-          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+        if (
+          isTypeof(
+            node,
+            z.object({
+              loc: z.object({
+                start: z.object({
+                  line: z.number(),
+                }),
+              }),
+            }),
+          )
+        ) {
+          const currentNodeStartLineIndex = node.loc.start.line - 1;
 
-          if (
-            currentNodeRangeStart <= classNameRangeStart &&
-            classNameRangeEnd <= currentNodeRangeEnd
-          ) {
-            if (classNameNode.type === ClassNameType.USL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.CSL;
-            } else if (classNameNode.type === ClassNameType.UTL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.CTL;
+          classNameNodes.forEach((classNameNode) => {
+            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+
+            if (
+              currentNodeRangeStart <= classNameRangeStart &&
+              classNameRangeEnd <= currentNodeRangeEnd
+            ) {
+              if (classNameNode.type === ClassNameType.USL) {
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.type = ClassNameType.CSL;
+              } else if (classNameNode.type === ClassNameType.UTL) {
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.type =
+                  classNameNode.startLineIndex === currentNodeStartLineIndex
+                    ? ClassNameType.TLSL
+                    : ClassNameType.CTL;
+              }
             }
-          }
-        });
+          });
+        }
         break;
       }
       case 'ObjectProperty':

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -152,40 +152,39 @@ function replaceClassName({
       )}${classNameWithoutSpacesAtBothEnds}`;
 
       const formattedClassName = ((cn: string) => {
-        function recursion(input: string): string {
-          const formatted = format(input, {
-            ...options,
-            parser: 'html',
-            plugins: [],
-            rangeStart: 0,
-            rangeEnd: Infinity,
-            endOfLine: 'lf',
-          }).trimEnd();
+        const formatted = format(cn, {
+          ...options,
+          parser: 'html',
+          plugins: [],
+          rangeStart: 0,
+          rangeEnd: Infinity,
+          endOfLine: 'lf',
+        }).trimEnd();
 
-          if (!isOutputIdeal) {
-            return formatted;
-          }
-
-          const [firstLine, ...rest] = formatted.split(EOL);
-
-          if (rest.length === 0) {
-            return firstLine;
-          }
-
-          const multiLinePadLength = indentUnit.repeat(multiLineIndentLevel).length;
-
-          // preprocess (n)
-          const classNameWithMultiLinePadding = `${PH.repeat(multiLinePadLength)}${rest.join(EOL)}`;
-
-          const recursivelyFormatted = recursion(classNameWithMultiLinePadding);
-
-          // postprocess (n)
-          const classNameWithoutMultiLinePadding = recursivelyFormatted.slice(multiLinePadLength);
-
-          return `${firstLine}${EOL}${classNameWithoutMultiLinePadding}`;
+        if (!isOutputIdeal) {
+          return formatted;
         }
 
-        return recursion(cn);
+        const [firstLine, ...rest] = formatted.split(EOL);
+
+        if (rest.length === 0) {
+          return firstLine;
+        }
+
+        const multiLinePadLength =
+          (indentUnit === '\t' ? 4 : indentUnit.length) * multiLineIndentLevel;
+
+        const formattedRest = format(rest.join(EOL), {
+          ...options,
+          parser: 'html',
+          plugins: [],
+          rangeStart: 0,
+          rangeEnd: Infinity,
+          endOfLine: 'lf',
+          printWidth: options.printWidth - multiLinePadLength,
+        }).trimEnd();
+
+        return `${firstLine}${EOL}${formattedRest}`;
       })(classNameWithFirstLinePadding);
 
       // postprocess (last-1)
@@ -324,42 +323,43 @@ async function replaceClassNameAsync({
       )}${classNameWithoutSpacesAtBothEnds}`;
 
       const formattedClassName = await (async (cn: string) => {
-        async function recursion(input: string): Promise<string> {
-          const formatted = (
-            await format(input, {
-              ...options,
-              parser: 'html',
-              plugins: [],
-              rangeStart: 0,
-              rangeEnd: Infinity,
-              endOfLine: 'lf',
-            })
-          ).trimEnd();
+        const formatted = (
+          await format(cn, {
+            ...options,
+            parser: 'html',
+            plugins: [],
+            rangeStart: 0,
+            rangeEnd: Infinity,
+            endOfLine: 'lf',
+          })
+        ).trimEnd();
 
-          if (!isOutputIdeal) {
-            return formatted;
-          }
-
-          const [firstLine, ...rest] = formatted.split(EOL);
-
-          if (rest.length === 0) {
-            return firstLine;
-          }
-
-          const multiLinePadLength = indentUnit.repeat(multiLineIndentLevel).length;
-
-          // preprocess (n)
-          const classNameWithMultiLinePadding = `${PH.repeat(multiLinePadLength)}${rest.join(EOL)}`;
-
-          const recursivelyFormatted = await recursion(classNameWithMultiLinePadding);
-
-          // postprocess (n)
-          const classNameWithoutMultiLinePadding = recursivelyFormatted.slice(multiLinePadLength);
-
-          return `${firstLine}${EOL}${classNameWithoutMultiLinePadding}`;
+        if (!isOutputIdeal) {
+          return formatted;
         }
 
-        return recursion(cn);
+        const [firstLine, ...rest] = formatted.split(EOL);
+
+        if (rest.length === 0) {
+          return firstLine;
+        }
+
+        const multiLinePadLength =
+          (indentUnit === '\t' ? 4 : indentUnit.length) * multiLineIndentLevel;
+
+        const formattedRest = (
+          await format(rest.join(EOL), {
+            ...options,
+            parser: 'html',
+            plugins: [],
+            rangeStart: 0,
+            rangeEnd: Infinity,
+            endOfLine: 'lf',
+            printWidth: options.printWidth - multiLinePadLength,
+          })
+        ).trimEnd();
+
+        return `${firstLine}${EOL}${formattedRest}`;
       })(classNameWithFirstLinePadding);
 
       // postprocess (last-1)

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -144,7 +144,11 @@ function replaceClassName({
         .split(EOL)
         .slice(0, startLineIndex)
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
-      const firstLinePadLength = rangeStart + 1 - totalTextLengthUptoPrevLine;
+      const firstLinePadLength =
+        rangeStart +
+        1 -
+        totalTextLengthUptoPrevLine +
+        (indentUnit === '\t' ? 3 : 0) * baseIndentLevel;
 
       // preprocess (first+1)
       const classNameWithFirstLinePadding = `${PH.repeat(
@@ -315,7 +319,11 @@ async function replaceClassNameAsync({
         .split(EOL)
         .slice(0, startLineIndex)
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
-      const firstLinePadLength = rangeStart + 1 - totalTextLengthUptoPrevLine;
+      const firstLinePadLength =
+        rangeStart +
+        1 -
+        totalTextLengthUptoPrevLine +
+        (indentUnit === '\t' ? 3 : 0) * baseIndentLevel;
 
       // preprocess (first+1)
       const classNameWithFirstLinePadding = `${PH.repeat(

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -32,6 +32,10 @@ export enum ClassNameType {
    */
   CTL,
   /**
+   * Template literal starting on the same line as the attribute
+   */
+  TLSL,
+  /**
    * Template literal as object property
    */
   TLOP,

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -68,6 +68,7 @@ export type ClassNameNode = {
 };
 
 export type NarrowedParserOptions = {
+  printWidth: number;
   tabWidth: number;
   useTabs: boolean;
   singleQuote: boolean;

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -70,5 +70,5 @@ export type NarrowedParserOptions = {
   parser: string;
   customAttributes: string[];
   customFunctions: string[];
-  endingPosition: 'relative' | 'absolute';
+  endingPosition: 'relative' | 'absolute' | 'absolute-with-indent';
 };

--- a/src/packages/v2-plugin/options.ts
+++ b/src/packages/v2-plugin/options.ts
@@ -35,6 +35,12 @@ export const options: SupportOptions = {
         value: 'absolute',
         description: 'Each line ends at a `printWidth` distance from the start of the line.',
       },
+      {
+        since: '0.6.0',
+        value: 'absolute-with-indent',
+        description:
+          'Basically the same as the `absolute` option, but indentation respects the `relative` option.',
+      },
     ],
   },
 };

--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -75,31 +75,27 @@ function transformParser(
         );
       }
 
-      if (parserName === 'vue' || parserName === 'astro') {
-        const secondAst = defaultParser.parse(
-          secondFormattedText,
-          { [parserName]: defaultParser },
-          options,
-        );
-        const classNameSecondWrappedText = parseLineByLineAndReplace({
-          formattedText: secondFormattedText,
-          ast: secondAst,
-          // @ts-ignore
-          options,
-          format,
-          addon,
-          targetClassNameTypes: [ClassNameType.ASL, ClassNameType.AOL],
-        });
-
-        return {
-          type: 'FormattedText',
-          body: classNameSecondWrappedText,
-        };
-      }
+      const secondAst = defaultParser.parse(
+        secondFormattedText,
+        { [parserName]: defaultParser },
+        options,
+      );
+      const classNameSecondWrappedText = parseLineByLineAndReplace({
+        formattedText: secondFormattedText,
+        ast: secondAst,
+        // @ts-ignore
+        options,
+        format,
+        addon,
+        targetClassNameTypes:
+          parserName === 'vue' || parserName === 'astro'
+            ? [ClassNameType.ASL, ClassNameType.AOL]
+            : [ClassNameType.CTL, ClassNameType.TLSL],
+      });
 
       return {
         type: 'FormattedText',
-        body: secondFormattedText,
+        body: classNameSecondWrappedText,
       };
     },
     astFormat: 'classnames-ast',

--- a/src/packages/v3-plugin/options.ts
+++ b/src/packages/v3-plugin/options.ts
@@ -38,6 +38,12 @@ export const options: SupportOptions = {
         value: 'absolute',
         description: 'Each line ends at a `printWidth` distance from the start of the line.',
       },
+      {
+        since: '0.6.0',
+        value: 'absolute-with-indent',
+        description:
+          'Basically the same as the `absolute` option, but indentation respects the `relative` option.',
+      },
     ],
   },
 };

--- a/src/packages/v3-plugin/parsers.ts
+++ b/src/packages/v3-plugin/parsers.ts
@@ -74,27 +74,23 @@ function transformParser(
         );
       }
 
-      if (parserName === 'vue' || parserName === 'astro') {
-        const secondAst = await defaultParser.parse(secondFormattedText, options);
-        const classNameSecondWrappedText = await parseLineByLineAndReplaceAsync({
-          formattedText: secondFormattedText,
-          ast: secondAst,
-          // @ts-ignore
-          options,
-          format,
-          addon,
-          targetClassNameTypes: [ClassNameType.ASL, ClassNameType.AOL],
-        });
-
-        return {
-          type: 'FormattedText',
-          body: classNameSecondWrappedText,
-        };
-      }
+      const secondAst = await defaultParser.parse(secondFormattedText, options);
+      const classNameSecondWrappedText = await parseLineByLineAndReplaceAsync({
+        formattedText: secondFormattedText,
+        ast: secondAst,
+        // @ts-ignore
+        options,
+        format,
+        addon,
+        targetClassNameTypes:
+          parserName === 'vue' || parserName === 'astro'
+            ? [ClassNameType.ASL, ClassNameType.AOL]
+            : [ClassNameType.CTL, ClassNameType.TLSL],
+      });
 
       return {
         type: 'FormattedText',
-        body: secondFormattedText,
+        body: classNameSecondWrappedText,
       };
     },
     astFormat: 'classnames-ast',

--- a/tests/v2-test/astro/attribute-without-expression.test.ts
+++ b/tests/v2-test/astro/attribute-without-expression.test.ts
@@ -120,7 +120,7 @@ const fixtures: Fixture[] = [
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
   <slot />
@@ -135,6 +135,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+<div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+  <slot />
+</div>
+`,
+    output: `<div
+  class="rounded-xl border border-zinc-400/30 bg-gray-100/50
+    px-4 py-4 dark:border-neutral-500/30
+    dark:bg-neutral-900/50"
+>
+  <slot />
+</div>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v2-test/astro/expression.test.ts
+++ b/tests/v2-test/astro/expression.test.ts
@@ -368,6 +368,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute',
     },
   },
+  {
+    name: 'ending position (4)',
+    input: `
+<div class={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+  <slot />
+</div>
+`,
+    output: `<div
+  class={\`rounded-xl border border-zinc-400/30
+    bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+    dark:bg-neutral-900/50\`}
+>
+  <slot />
+</div>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('astro/expression', () => {

--- a/tests/v2-test/astro/expression.test.ts
+++ b/tests/v2-test/astro/expression.test.ts
@@ -388,6 +388,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute-with-indent',
     },
   },
+  {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+<div class={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+  <slot />
+</div>
+`,
+    output: `<div
+\tclass={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+>
+\t<slot />
+</div>
+`,
+    options: {
+      printWidth: 70,
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('astro/expression', () => {

--- a/tests/v2-test/babel/attribute-without-expression.test.ts
+++ b/tests/v2-test/babel/attribute-without-expression.test.ts
@@ -172,7 +172,7 @@ export function Callout({ children }) {
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 export function Callout({ children }) {
   return (
@@ -195,6 +195,34 @@ py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v2-test/babel/expression.test.ts
+++ b/tests/v2-test/babel/expression.test.ts
@@ -661,6 +661,33 @@ export function Callout({ children }) {
     },
   },
   {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+\treturn (
+\t\t<div
+\t\t\tclassName={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\t\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+\t\t>
+\t\t\t{children}
+\t\t</div>
+\t);
+}
+`,
+    options: {
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v2-test/babel/expression.test.ts
+++ b/tests/v2-test/babel/expression.test.ts
@@ -633,6 +633,34 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
     },
   },
   {
+    name: 'ending position (4)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className={\`rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50\`}
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v2-test/typescript/attribute-without-expression.test.ts
+++ b/tests/v2-test/typescript/attribute-without-expression.test.ts
@@ -172,7 +172,7 @@ export function Callout({ children }) {
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 export function Callout({ children }) {
   return (
@@ -195,6 +195,34 @@ py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v2-test/typescript/expression.test.ts
+++ b/tests/v2-test/typescript/expression.test.ts
@@ -661,6 +661,33 @@ export function Callout({ children }) {
     },
   },
   {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+\treturn (
+\t\t<div
+\t\t\tclassName={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\t\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+\t\t>
+\t\t\t{children}
+\t\t</div>
+\t);
+}
+`,
+    options: {
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v2-test/typescript/expression.test.ts
+++ b/tests/v2-test/typescript/expression.test.ts
@@ -633,6 +633,34 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
     },
   },
   {
+    name: 'ending position (4)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className={\`rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50\`}
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v2-test/vue/attribute-without-expression.test.ts
+++ b/tests/v2-test/vue/attribute-without-expression.test.ts
@@ -152,7 +152,7 @@ const fixtures: Fixture[] = [
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 <template>
   <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
@@ -171,6 +171,30 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+<template>
+  <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+  <div
+    class="rounded-xl border border-zinc-400/30
+      bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+      dark:bg-neutral-900/50"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v2-test/vue/expression.test.ts
+++ b/tests/v2-test/vue/expression.test.ts
@@ -480,6 +480,31 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute-with-indent',
     },
   },
+  {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+<template>
+  <div :class="'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+\t<div
+\t\t:class="\`rounded-xl border border-zinc-400/30 bg-gray-100/50
+\t\t\tpx-4 py-4 dark:border-neutral-500/30
+\t\t\tdark:bg-neutral-900/50\`"
+\t>
+\t\t<slot></slot>
+\t</div>
+</template>
+`,
+    options: {
+      printWidth: 70,
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('vue/expression', () => {

--- a/tests/v2-test/vue/expression.test.ts
+++ b/tests/v2-test/vue/expression.test.ts
@@ -456,6 +456,30 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute',
     },
   },
+  {
+    name: 'ending position (4)',
+    input: `
+<template>
+  <div :class="'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+  <div
+    :class="\`rounded-xl border border-zinc-400/30
+      bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+      dark:bg-neutral-900/50\`"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('vue/expression', () => {

--- a/tests/v3-test/astro/attribute-without-expression.test.ts
+++ b/tests/v3-test/astro/attribute-without-expression.test.ts
@@ -120,7 +120,7 @@ const fixtures: Fixture[] = [
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
   <slot />
@@ -135,6 +135,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+<div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+  <slot />
+</div>
+`,
+    output: `<div
+  class="rounded-xl border border-zinc-400/30 bg-gray-100/50
+    px-4 py-4 dark:border-neutral-500/30
+    dark:bg-neutral-900/50"
+>
+  <slot />
+</div>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v3-test/astro/expression.test.ts
+++ b/tests/v3-test/astro/expression.test.ts
@@ -368,6 +368,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute',
     },
   },
+  {
+    name: 'ending position (4)',
+    input: `
+<div class={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+  <slot />
+</div>
+`,
+    output: `<div
+  class={\`rounded-xl border border-zinc-400/30
+    bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+    dark:bg-neutral-900/50\`}
+>
+  <slot />
+</div>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('astro/expression', () => {

--- a/tests/v3-test/astro/expression.test.ts
+++ b/tests/v3-test/astro/expression.test.ts
@@ -388,6 +388,26 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute-with-indent',
     },
   },
+  {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+<div class={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+  <slot />
+</div>
+`,
+    output: `<div
+\tclass={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+>
+\t<slot />
+</div>
+`,
+    options: {
+      printWidth: 70,
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('astro/expression', () => {

--- a/tests/v3-test/babel/attribute-without-expression.test.ts
+++ b/tests/v3-test/babel/attribute-without-expression.test.ts
@@ -172,7 +172,7 @@ export function Callout({ children }) {
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 export function Callout({ children }) {
   return (
@@ -195,6 +195,34 @@ py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v3-test/babel/expression.test.ts
+++ b/tests/v3-test/babel/expression.test.ts
@@ -661,6 +661,33 @@ export function Callout({ children }) {
     },
   },
   {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+\treturn (
+\t\t<div
+\t\t\tclassName={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\t\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+\t\t>
+\t\t\t{children}
+\t\t</div>
+\t);
+}
+`,
+    options: {
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v3-test/babel/expression.test.ts
+++ b/tests/v3-test/babel/expression.test.ts
@@ -633,6 +633,34 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
     },
   },
   {
+    name: 'ending position (4)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className={\`rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50\`}
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v3-test/typescript/attribute-without-expression.test.ts
+++ b/tests/v3-test/typescript/attribute-without-expression.test.ts
@@ -172,7 +172,7 @@ export function Callout({ children }) {
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 export function Callout({ children }) {
   return (
@@ -195,6 +195,34 @@ py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className="rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50"
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v3-test/typescript/expression.test.ts
+++ b/tests/v3-test/typescript/expression.test.ts
@@ -661,6 +661,33 @@ export function Callout({ children }) {
     },
   },
   {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+\treturn (
+\t\t<div
+\t\t\tclassName={\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
+\t\t\t\tpy-4 dark:border-neutral-500/30 dark:bg-neutral-900/50\`}
+\t\t>
+\t\t\t{children}
+\t\t</div>
+\t);
+}
+`,
+    options: {
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v3-test/typescript/expression.test.ts
+++ b/tests/v3-test/typescript/expression.test.ts
@@ -633,6 +633,34 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
     },
   },
   {
+    name: 'ending position (4)',
+    input: `
+export function Callout({ children }) {
+  return (
+    <div className={'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'}>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Callout({ children }) {
+  return (
+    <div
+      className={\`rounded-xl border border-zinc-400/30
+        bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+        dark:bg-neutral-900/50\`}
+    >
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
     name: 'issue #27 (1) - template literal ending with a space',
     input: `
 export default function Test() {

--- a/tests/v3-test/vue/attribute-without-expression.test.ts
+++ b/tests/v3-test/vue/attribute-without-expression.test.ts
@@ -152,7 +152,7 @@ const fixtures: Fixture[] = [
 `,
   },
   {
-    name: 'ending position',
+    name: 'ending position (1)',
     input: `
 <template>
   <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
@@ -171,6 +171,30 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50"
 `,
     options: {
       endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'ending position (2)',
+    input: `
+<template>
+  <div class="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+  <div
+    class="rounded-xl border border-zinc-400/30
+      bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+      dark:bg-neutral-900/50"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
     },
   },
 ];

--- a/tests/v3-test/vue/expression.test.ts
+++ b/tests/v3-test/vue/expression.test.ts
@@ -480,6 +480,31 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute-with-indent',
     },
   },
+  {
+    name: 'ending position (5) - useTabs: true',
+    input: `
+<template>
+  <div :class="'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+\t<div
+\t\t:class="\`rounded-xl border border-zinc-400/30 bg-gray-100/50
+\t\t\tpx-4 py-4 dark:border-neutral-500/30
+\t\t\tdark:bg-neutral-900/50\`"
+\t>
+\t\t<slot></slot>
+\t</div>
+</template>
+`,
+    options: {
+      printWidth: 70,
+      useTabs: true,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('vue/expression', () => {

--- a/tests/v3-test/vue/expression.test.ts
+++ b/tests/v3-test/vue/expression.test.ts
@@ -456,6 +456,30 @@ dark:border-neutral-500/30 dark:bg-neutral-900/50\`]: true,
       endingPosition: 'absolute',
     },
   },
+  {
+    name: 'ending position (4)',
+    input: `
+<template>
+  <div :class="'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50'">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<template>
+  <div
+    :class="\`rounded-xl border border-zinc-400/30
+      bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30
+      dark:bg-neutral-900/50\`"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+      endingPosition: 'absolute-with-indent',
+    },
+  },
 ];
 
 describe('vue/expression', () => {


### PR DESCRIPTION
This PR closes #32.

See #26 for an explanation of `endingPosition`.

## How is it different from existing options?

### `absolute-with-indent`

Basically the same as the `absolute` option, but indentation respects the `relative` option.

Example output:

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
      className="bg-gray-100/50 border
        border-zinc-400/30 dark:bg-neutral-900/50
        dark:border-neutral-500/30 px-4 py-4
        rounded-xl"
    >
      {children}
    </div>
  );
}
```

```
--------------------------------------------------| printWidth=50
export function Callout({ children }) {
  return (
    <div
      className={classNames(
        `bg-gray-100/50 border border-zinc-400/30
        dark:bg-neutral-900/50
        dark:border-neutral-500/30 px-4 py-4
        rounded-xl`,
      )}
    >
      {children}
    </div>
  );
}
```