### PR TITLE
Fix delimiter for certain types of short enough class names written in vue expressions

### DIFF
--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -57,7 +57,10 @@ function getSomeKindOfQuotes(
         parser === 'vue' &&
         [
           ClassNameType.FA,
+          ClassNameType.CSL,
           ClassNameType.SLSL,
+          ClassNameType.SLOP,
+          ClassNameType.SLTO,
           ClassNameType.CTL,
           ClassNameType.TLSL,
           ClassNameType.TLOP,

--- a/tests/v2-test/vue/expression.test.ts
+++ b/tests/v2-test/vue/expression.test.ts
@@ -385,6 +385,27 @@ import clsx from "clsx";
 `,
   },
   {
+    name: 'issue #37 - short enough conditional class name (no error in v0.4.0, error in v0.5.0 ~ v0.6.0)',
+    input: `
+<template>
+  <div
+    :class="{
+        'bg-black': true
+    }">Some text</div>
+</template>
+`,
+    output: `<template>
+  <div
+    :class="{
+      'bg-black': true,
+    }"
+  >
+    Some text
+  </div>
+</template>
+`,
+  },
+  {
     name: 'ending position (1)',
     input: `
 <template>

--- a/tests/v2-test/vue/expression.test.ts
+++ b/tests/v2-test/vue/expression.test.ts
@@ -406,6 +406,282 @@ import clsx from "clsx";
 `,
   },
   {
+    name: 'class name type checking (1) - short enough FA',
+    input: `
+<script setup lang="ts">
+const foo = classNames('rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4');
+</script>
+
+<template>
+  <div :class="classNames('rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4')">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames(
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+);
+</script>
+
+<template>
+  <div
+    :class="
+      classNames(
+        'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      )
+    "
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (2) - short enough CSL',
+    input: `
+<script setup lang="ts">
+const foo = ['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4', 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'];
+</script>
+
+<template>
+  <div :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4', 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+];
+</script>
+
+<template>
+  <div
+    :class="[
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (3) - short enough SLSL',
+    input: `
+<script setup lang="ts">
+const foo = ['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'];
+</script>
+
+<template>
+  <div :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = ["rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"];
+</script>
+
+<template>
+  <div
+    :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (4) - short enough SLOP',
+    input: `
+<script setup lang="ts">
+const foo = classNames({'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true});
+</script>
+
+<template>
+  <div :class="{'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true}">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames({
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4": true,
+});
+</script>
+
+<template>
+  <div
+    :class="{
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true,
+    }"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (5) - short enough SLTO',
+    input: `
+<script setup lang="ts">
+const foo = classNames([true ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4' : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']);
+</script>
+
+<template>
+  <div :class="[true ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4' : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames([
+  true
+    ? "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"
+    : "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+]);
+</script>
+
+<template>
+  <div
+    :class="[
+      true
+        ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'
+        : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (6) - short enough CTL',
+    input: `
+<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`, \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div :class="[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`, \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [
+  \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`,
+  \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`,
+];
+</script>
+
+<template>
+  <div
+    :class="[
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (7) - short enough TLSL',
+    input: `
+<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div :class="[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div
+    :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (8) - short enough TLOP',
+    input: `
+<script setup lang="ts">
+const foo = classNames({[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]: true});
+</script>
+
+<template>
+  <div :class="{[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]: true}">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames({
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4": true,
+});
+</script>
+
+<template>
+  <div
+    :class="{
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true,
+    }"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (9) - short enough TLTO',
+    input: `
+<script setup lang="ts">
+const foo = classNames([true ? \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\` : \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]);
+</script>
+
+<template>
+  <div :class="[true ? \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\` : \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames([
+  true
+    ? "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"
+    : "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+]);
+</script>
+
+<template>
+  <div
+    :class="[
+      true
+        ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'
+        : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
     name: 'ending position (1)',
     input: `
 <template>

--- a/tests/v3-test/vue/expression.test.ts
+++ b/tests/v3-test/vue/expression.test.ts
@@ -385,6 +385,27 @@ import clsx from "clsx";
 `,
   },
   {
+    name: 'issue #37 - short enough conditional class name (no error in v0.4.0, error in v0.5.0 ~ v0.6.0)',
+    input: `
+<template>
+  <div
+    :class="{
+        'bg-black': true
+    }">Some text</div>
+</template>
+`,
+    output: `<template>
+  <div
+    :class="{
+      'bg-black': true,
+    }"
+  >
+    Some text
+  </div>
+</template>
+`,
+  },
+  {
     name: 'ending position (1)',
     input: `
 <template>

--- a/tests/v3-test/vue/expression.test.ts
+++ b/tests/v3-test/vue/expression.test.ts
@@ -406,6 +406,282 @@ import clsx from "clsx";
 `,
   },
   {
+    name: 'class name type checking (1) - short enough FA',
+    input: `
+<script setup lang="ts">
+const foo = classNames('rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4');
+</script>
+
+<template>
+  <div :class="classNames('rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4')">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames(
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+);
+</script>
+
+<template>
+  <div
+    :class="
+      classNames(
+        'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      )
+    "
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (2) - short enough CSL',
+    input: `
+<script setup lang="ts">
+const foo = ['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4', 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'];
+</script>
+
+<template>
+  <div :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4', 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+];
+</script>
+
+<template>
+  <div
+    :class="[
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (3) - short enough SLSL',
+    input: `
+<script setup lang="ts">
+const foo = ['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'];
+</script>
+
+<template>
+  <div :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = ["rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"];
+</script>
+
+<template>
+  <div
+    :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (4) - short enough SLOP',
+    input: `
+<script setup lang="ts">
+const foo = classNames({'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true});
+</script>
+
+<template>
+  <div :class="{'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true}">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames({
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4": true,
+});
+</script>
+
+<template>
+  <div
+    :class="{
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true,
+    }"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (5) - short enough SLTO',
+    input: `
+<script setup lang="ts">
+const foo = classNames([true ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4' : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']);
+</script>
+
+<template>
+  <div :class="[true ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4' : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames([
+  true
+    ? "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"
+    : "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+]);
+</script>
+
+<template>
+  <div
+    :class="[
+      true
+        ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'
+        : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (6) - short enough CTL',
+    input: `
+<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`, \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div :class="[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`, \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [
+  \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`,
+  \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`,
+];
+</script>
+
+<template>
+  <div
+    :class="[
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (7) - short enough TLSL',
+    input: `
+<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div :class="[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = [\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`];
+</script>
+
+<template>
+  <div
+    :class="['rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4']"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (8) - short enough TLOP',
+    input: `
+<script setup lang="ts">
+const foo = classNames({[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]: true});
+</script>
+
+<template>
+  <div :class="{[\`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]: true}">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames({
+  "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4": true,
+});
+</script>
+
+<template>
+  <div
+    :class="{
+      'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4': true,
+    }"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
+    name: 'class name type checking (9) - short enough TLTO',
+    input: `
+<script setup lang="ts">
+const foo = classNames([true ? \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\` : \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]);
+</script>
+
+<template>
+  <div :class="[true ? \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\` : \`rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4\`]">
+    <slot></slot>
+  </div>
+</template>
+`,
+    output: `<script setup lang="ts">
+const foo = classNames([
+  true
+    ? "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4"
+    : "rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4",
+]);
+</script>
+
+<template>
+  <div
+    :class="[
+      true
+        ? 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4'
+        : 'rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4',
+    ]"
+  >
+    <slot></slot>
+  </div>
+</template>
+`,
+  },
+  {
     name: 'ending position (1)',
     input: `
 <template>


### PR DESCRIPTION
This PR closes #37.