### PR TITLE
Makes output consistent for attribute type class names

### DIFF
--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -168,6 +168,9 @@ export function findTargetClassNameNodes(
                   line: z.unknown(),
                 }),
               }),
+              name: z.object({
+                name: z.string(),
+              }),
             }),
           ) &&
           parentNode.type === 'JSXOpeningElement' &&
@@ -206,6 +209,8 @@ export function findTargetClassNameNodes(
                   parentNodeStartLineNumber === currentNodeStartLineNumber
                     ? ClassNameType.ASL
                     : ClassNameType.AOL;
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.elementName = parentNode.name.name;
               }
             }
           });

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -94,6 +94,7 @@ export type ClassNameNode = {
   type: ClassNameType;
   range: NodeRange;
   startLineIndex: number;
+  elementName?: string;
 };
 
 export type NarrowedParserOptions = {

--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -90,7 +90,7 @@ function transformParser(
         targetClassNameTypes:
           parserName === 'vue' || parserName === 'astro'
             ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.CTL, ClassNameType.TLSL],
+            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL],
       });
 
       return {

--- a/src/packages/v3-plugin/parsers.ts
+++ b/src/packages/v3-plugin/parsers.ts
@@ -85,7 +85,7 @@ function transformParser(
         targetClassNameTypes:
           parserName === 'vue' || parserName === 'astro'
             ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.CTL, ClassNameType.TLSL],
+            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL],
       });
 
       return {

--- a/tests/v2-test/babel/attribute-without-expression.test.ts
+++ b/tests/v2-test/babel/attribute-without-expression.test.ts
@@ -185,8 +185,8 @@ export function Callout({ children }) {
     output: `export function Callout({ children }) {
   return (
     <div
-      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
-py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+dark:border-neutral-500/30 dark:bg-neutral-900/50"
     >
       {children}
     </div>

--- a/tests/v2-test/babel/consistency.test.ts
+++ b/tests/v2-test/babel/consistency.test.ts
@@ -1,0 +1,193 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'issue #41 (1) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (2) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (3) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (4) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (5) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
+    name: 'issue #41 (6) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+];
+
+describe('babel/consistency', () => {
+  for (const fixture of fixtures) {
+    const fixedOptions = {
+      ...options,
+      ...(fixture.options ?? {}),
+    };
+    const formattedText = format(fixture.input, fixedOptions);
+
+    describe(fixture.name, () => {
+      test('expectation', () => {
+        expect(formattedText).toBe(fixture.output);
+      });
+
+      test('consistency', () => {
+        const doubleFormattedText = format(formattedText, fixedOptions);
+
+        expect(doubleFormattedText).toBe(formattedText);
+      });
+    });
+  }
+});

--- a/tests/v2-test/typescript/attribute-without-expression.test.ts
+++ b/tests/v2-test/typescript/attribute-without-expression.test.ts
@@ -185,8 +185,8 @@ export function Callout({ children }) {
     output: `export function Callout({ children }) {
   return (
     <div
-      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
-py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+dark:border-neutral-500/30 dark:bg-neutral-900/50"
     >
       {children}
     </div>

--- a/tests/v2-test/typescript/consistency.test.ts
+++ b/tests/v2-test/typescript/consistency.test.ts
@@ -1,0 +1,193 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'issue #41 (1) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (2) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (3) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (4) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (5) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
+    name: 'issue #41 (6) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+];
+
+describe('typescript/consistency', () => {
+  for (const fixture of fixtures) {
+    const fixedOptions = {
+      ...options,
+      ...(fixture.options ?? {}),
+    };
+    const formattedText = format(fixture.input, fixedOptions);
+
+    describe(fixture.name, () => {
+      test('expectation', () => {
+        expect(formattedText).toBe(fixture.output);
+      });
+
+      test('consistency', () => {
+        const doubleFormattedText = format(formattedText, fixedOptions);
+
+        expect(doubleFormattedText).toBe(formattedText);
+      });
+    });
+  }
+});

--- a/tests/v3-test/babel/attribute-without-expression.test.ts
+++ b/tests/v3-test/babel/attribute-without-expression.test.ts
@@ -185,8 +185,8 @@ export function Callout({ children }) {
     output: `export function Callout({ children }) {
   return (
     <div
-      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
-py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+dark:border-neutral-500/30 dark:bg-neutral-900/50"
     >
       {children}
     </div>

--- a/tests/v3-test/babel/consistency.test.ts
+++ b/tests/v3-test/babel/consistency.test.ts
@@ -1,0 +1,196 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'issue #41 (1) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (2) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (3) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (4) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (5) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
+    name: 'issue #41 (6) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+];
+
+describe('babel/consistency', () => {
+  for (const fixture of fixtures) {
+    const fixedOptions = {
+      ...options,
+      ...(fixture.options ?? {}),
+    };
+    const promise = format(fixture.input, fixedOptions);
+
+    describe(fixture.name, () => {
+      test('expectation', async () => {
+        const formattedText = await promise;
+
+        expect(formattedText).toBe(fixture.output);
+      });
+
+      test('consistency', async () => {
+        const formattedText = await promise;
+        const doubleFormattedText = await format(formattedText, fixedOptions);
+
+        expect(doubleFormattedText).toBe(formattedText);
+      });
+    });
+  }
+});

--- a/tests/v3-test/typescript/attribute-without-expression.test.ts
+++ b/tests/v3-test/typescript/attribute-without-expression.test.ts
@@ -185,8 +185,8 @@ export function Callout({ children }) {
     output: `export function Callout({ children }) {
   return (
     <div
-      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4
-py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
+      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
+dark:border-neutral-500/30 dark:bg-neutral-900/50"
     >
       {children}
     </div>

--- a/tests/v3-test/typescript/consistency.test.ts
+++ b/tests/v3-test/typescript/consistency.test.ts
@@ -1,0 +1,196 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'issue #41 (1) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (2) - relative',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'relative',
+    },
+  },
+  {
+    name: 'issue #41 (3) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (4) - absolute',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute',
+    },
+  },
+  {
+    name: 'issue #41 (5) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p">
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+  {
+    name: 'issue #41 (6) - ideal',
+    input: `
+export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit
+        aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    output: `export default function MyComponent() {
+  return (
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+    >
+      content
+    </section>
+  );
+}
+`,
+    options: {
+      endingPosition: 'absolute-with-indent',
+    },
+  },
+];
+
+describe('typescript/consistency', () => {
+  for (const fixture of fixtures) {
+    const fixedOptions = {
+      ...options,
+      ...(fixture.options ?? {}),
+    };
+    const promise = format(fixture.input, fixedOptions);
+
+    describe(fixture.name, () => {
+      test('expectation', async () => {
+        const formattedText = await promise;
+
+        expect(formattedText).toBe(fixture.output);
+      });
+
+      test('consistency', async () => {
+        const formattedText = await promise;
+        const doubleFormattedText = await format(formattedText, fixedOptions);
+
+        expect(doubleFormattedText).toBe(formattedText);
+      });
+    });
+  }
+});


### PR DESCRIPTION
This PR closes #41.

## Side effects on attribute type class names:

If formatting results in the attribute type class name being placed on a different line than the JSX opening element, the available width is calculated based on the result.

This side effect only applies to javascript and typescript code, and requires that the `endingPosition` option be set to `absolute` or `absolute-with-indent`.

For example, if you apply formatting to code like this:

```
--------------------------------------------------------------------------------| printWidth=80
export function Callout({ children }) {
  return (
    <div className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50">
      {children}
    </div>
  );
}
```

Until now, for attributes located on the same line as the JSX opening element, the available width was less than the `printWidth` value.

```
export function Callout({ children }) {
  return (
    <div
--------------------------------------------------------------------------------| printWidth=80
      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 ______
                                                                          ^
                                               There is enough space for `py-4`, but it is not used.
        py-4 dark:border-neutral-500/30 dark:bg-neutral-900/50"
    >
      {children}
    </div>
  );
}
```

After this PR is merged, attributes located on the same line as the JSX opening element will also use a width equal to the `printWidth` value.

```
export function Callout({ children }) {
  return (
    <div
--------------------------------------------------------------------------------| printWidth=80
      className="rounded-xl border border-zinc-400/30 bg-gray-100/50 px-4 py-4
        dark:border-neutral-500/30 dark:bg-neutral-900/50"
    >
      {children}
    </div>
  );
}
```