### PR TITLE
Ensures that class names written after non-ASCII characters in Astro code do not leave placeholder fragments

### DIFF
--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -371,7 +371,7 @@ export function parseLineByLineAndReplace({
   let targetClassNameNodes: ClassNameNode[] = [];
   switch (options.parser) {
     case 'astro': {
-      targetClassNameNodes = findTargetClassNameNodesForAstro(ast, options, addon);
+      targetClassNameNodes = findTargetClassNameNodesForAstro(formattedText, ast, options, addon);
       break;
     }
     case 'vue': {
@@ -638,7 +638,7 @@ export async function parseLineByLineAndReplaceAsync({
   let targetClassNameNodes: ClassNameNode[] = [];
   switch (options.parser) {
     case 'astro': {
-      targetClassNameNodes = findTargetClassNameNodesForAstro(ast, options, addon);
+      targetClassNameNodes = findTargetClassNameNodesForAstro(formattedText, ast, options, addon);
       break;
     }
     case 'vue': {

--- a/tests/v2-test/astro/issue-50/absolute.test.ts
+++ b/tests/v2-test/astro/issue-50/absolute.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/astro/issue-50/absolute.test.ts
+++ b/tests/v2-test/astro/issue-50/absolute.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v2-test/astro/issue-50/ideal.test.ts
+++ b/tests/v2-test/astro/issue-50/ideal.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v2-test/astro/issue-50/ideal.test.ts
+++ b/tests/v2-test/astro/issue-50/ideal.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/astro/issue-50/relative.test.ts
+++ b/tests/v2-test/astro/issue-50/relative.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v2-test/astro/issue-50/relative.test.ts
+++ b/tests/v2-test/astro/issue-50/relative.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-50/absolute.test.ts
+++ b/tests/v3-test/astro/issue-50/absolute.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v3-test/astro/issue-50/absolute.test.ts
+++ b/tests/v3-test/astro/issue-50/absolute.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-50/ideal.test.ts
+++ b/tests/v3-test/astro/issue-50/ideal.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v3-test/astro/issue-50/ideal.test.ts
+++ b/tests/v3-test/astro/issue-50/ideal.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-50/relative.test.ts
+++ b/tests/v3-test/astro/issue-50/relative.test.ts
@@ -51,7 +51,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />
@@ -63,7 +63,7 @@ import SecurityForm from "./_security";
 ---
 
 <SettingsLayout
-  title="Settings ⚙ Details"
+  title="Settings 😂 Details"
   class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
 >
   <SecurityForm client:only />

--- a/tests/v3-test/astro/issue-50/relative.test.ts
+++ b/tests/v3-test/astro/issue-50/relative.test.ts
@@ -1,0 +1,119 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'bullet character',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings • Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'emoji',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="Settings ⚙ Details"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+  {
+    name: 'i18n - Korean',
+    input: `
+---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+    output: `---
+import SettingsLayout from "@layouts/settings.astro";
+import SecurityForm from "./_security";
+---
+
+<SettingsLayout
+  title="설정 * 세부정보"
+  class="flex max-w-[1100px] flex-col gap-4 overflow-x-hidden text-left"
+>
+  <SecurityForm client:only />
+</SettingsLayout>
+`,
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});


### PR DESCRIPTION
This PR closes #50.