### PR TITLE
Correctly applies the `jsxSingleQuote` option to formatting results

### DIFF
--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -283,24 +283,24 @@ function replaceClassName({
 
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
-      const substitute =
-        `${quoteStart}${classNameWithOriginalSpaces}${quoteEnd}`
-          .split(EOL)
-          .map((raw) => {
-            const frozen = freezeClassName(raw);
 
-            freezer.push({
-              type: 'string',
-              from: frozen,
-              to: raw,
-            });
+      const isAttributeType = type === ClassNameType.ASL || type === ClassNameType.AOL;
+      const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
+        isAttributeType ? '' : quoteEnd
+      }`
+        .split(EOL)
+        .map((raw) => {
+          const frozen = freezeClassName(raw);
 
-            return frozen;
-          })
-          .join(`${EOL}${frozenIndent}`) +
-        (conditionForSameLineAttribute || conditionForOwnLineAttribute
-          ? `${EOL}${frozenAttributeName}${EOL}`
-          : '');
+          freezer.push({
+            type: 'string',
+            from: frozen,
+            to: raw,
+          });
+
+          return frozen;
+        })
+        .join(`${EOL}${frozenIndent}`);
 
       if (isStartingPositionRelative && isMultiLineClassName) {
         freezer.push({
@@ -313,8 +313,19 @@ function replaceClassName({
       const sliceOffset = !isMultiLineClassName && type === ClassNameType.TLOP ? 1 : 0;
       const classNamePartialWrappedText = `${formattedPrevText.slice(
         0,
-        rangeStart - sliceOffset,
-      )}${substitute}${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
+        rangeStart - sliceOffset + (isAttributeType ? 1 : 0),
+      )}${substitute}${
+        isAttributeType
+          ? formattedPrevText.slice(
+              correctedRangeEnd + sliceOffset - 1,
+              correctedRangeEnd + sliceOffset,
+            )
+          : ''
+      }${
+        conditionForSameLineAttribute || conditionForOwnLineAttribute
+          ? `${EOL}${frozenAttributeName}${EOL}`
+          : ''
+      }${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
 
       rangeCorrectionValues.forEach((_, rangeCorrectionIndex, array) => {
         if (rangeCorrectionIndex <= classNameNodeIndex) {
@@ -550,24 +561,24 @@ async function replaceClassNameAsync({
 
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
-      const substitute =
-        `${quoteStart}${classNameWithOriginalSpaces}${quoteEnd}`
-          .split(EOL)
-          .map((raw) => {
-            const frozen = freezeClassName(raw);
 
-            freezer.push({
-              type: 'string',
-              from: frozen,
-              to: raw,
-            });
+      const isAttributeType = type === ClassNameType.ASL || type === ClassNameType.AOL;
+      const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
+        isAttributeType ? '' : quoteEnd
+      }`
+        .split(EOL)
+        .map((raw) => {
+          const frozen = freezeClassName(raw);
 
-            return frozen;
-          })
-          .join(`${EOL}${frozenIndent}`) +
-        (conditionForSameLineAttribute || conditionForOwnLineAttribute
-          ? `${EOL}${frozenAttributeName}${EOL}`
-          : '');
+          freezer.push({
+            type: 'string',
+            from: frozen,
+            to: raw,
+          });
+
+          return frozen;
+        })
+        .join(`${EOL}${frozenIndent}`);
 
       if (isStartingPositionRelative && isMultiLineClassName) {
         freezer.push({
@@ -580,8 +591,19 @@ async function replaceClassNameAsync({
       const sliceOffset = !isMultiLineClassName && type === ClassNameType.TLOP ? 1 : 0;
       const classNamePartialWrappedText = `${formattedPrevText.slice(
         0,
-        rangeStart - sliceOffset,
-      )}${substitute}${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
+        rangeStart - sliceOffset + (isAttributeType ? 1 : 0),
+      )}${substitute}${
+        isAttributeType
+          ? formattedPrevText.slice(
+              correctedRangeEnd + sliceOffset - 1,
+              correctedRangeEnd + sliceOffset,
+            )
+          : ''
+      }${
+        conditionForSameLineAttribute || conditionForOwnLineAttribute
+          ? `${EOL}${frozenAttributeName}${EOL}`
+          : ''
+      }${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
 
       rangeCorrectionValues.forEach((_, rangeCorrectionIndex, array) => {
         if (rangeCorrectionIndex <= classNameNodeIndex) {

--- a/tests/v2-test/astro/issue-54/absolute.test.ts
+++ b/tests/v2-test/astro/issue-54/absolute.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/astro/issue-54/ideal.test.ts
+++ b/tests/v2-test/astro/issue-54/ideal.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/astro/issue-54/relative.test.ts
+++ b/tests/v2-test/astro/issue-54/relative.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/babel/issue-54/absolute.test.ts
+++ b/tests/v2-test/babel/issue-54/absolute.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/babel/issue-54/ideal.test.ts
+++ b/tests/v2-test/babel/issue-54/ideal.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/babel/issue-54/relative.test.ts
+++ b/tests/v2-test/babel/issue-54/relative.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/typescript/issue-54/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-54/absolute.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/typescript/issue-54/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-54/ideal.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v2-test/typescript/issue-54/relative.test.ts
+++ b/tests/v2-test/typescript/issue-54/relative.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v2-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', () => {
+    const doubleFormattedText = format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-54/absolute.test.ts
+++ b/tests/v3-test/astro/issue-54/absolute.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-54/ideal.test.ts
+++ b/tests/v3-test/astro/issue-54/ideal.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/astro/issue-54/relative.test.ts
+++ b/tests/v3-test/astro/issue-54/relative.test.ts
@@ -1,0 +1,127 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum do'or sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum dolor sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    output: `<div>
+  <div>
+    <div class='lorem ipsum do"or sit amet'>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/babel/issue-54/absolute.test.ts
+++ b/tests/v3-test/babel/issue-54/absolute.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/babel/issue-54/ideal.test.ts
+++ b/tests/v3-test/babel/issue-54/ideal.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/babel/issue-54/relative.test.ts
+++ b/tests/v3-test/babel/issue-54/relative.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/typescript/issue-54/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-54/absolute.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/typescript/issue-54/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-54/ideal.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});

--- a/tests/v3-test/typescript/issue-54/relative.test.ts
+++ b/tests/v3-test/typescript/issue-54/relative.test.ts
@@ -1,0 +1,111 @@
+import { format } from 'prettier';
+import type { Fixture } from 'test-settings';
+import { baseOptions } from 'test-settings';
+import { describe, expect, test } from 'vitest';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as thisPlugin from '@/packages/v3-plugin';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'delimiter conversion (1) - `jsxSingleQuote: true`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum dolor sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (2) - `jsxSingleQuote: true` but the class name includes a single quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum do'or sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum do'or sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: true,
+    },
+  },
+  {
+    name: 'delimiter conversion (3) - `jsxSingleQuote: false`',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum dolor sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className="lorem ipsum dolor sit amet">{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+  {
+    name: 'delimiter conversion (4) - `jsxSingleQuote: false` but the class name includes a double quote',
+    input: `
+export function Foo({ children }) {
+  return (
+    <div className='lorem ipsum do"or sit amet'>
+      {children}
+    </div>
+  );
+}
+`,
+    output: `export function Foo({ children }) {
+  return <div className='lorem ipsum do"or sit amet'>{children}</div>;
+}
+`,
+    options: {
+      jsxSingleQuote: false,
+    },
+  },
+];
+
+describe.each(fixtures)('$name', async ({ input, output, options: fixtureOptions }) => {
+  const fixedOptions = {
+    ...options,
+    ...(fixtureOptions ?? {}),
+  };
+  const formattedText = await format(input, fixedOptions);
+
+  test('expectation', () => {
+    expect(formattedText).toBe(output);
+  });
+
+  test.runIf(formattedText === output)('consistency', async () => {
+    const doubleFormattedText = await format(formattedText, fixedOptions);
+
+    expect(doubleFormattedText).toBe(formattedText);
+  });
+});


### PR DESCRIPTION
This PR closes #54.