### PR TITLE
Makes class name nodes flexible

### DIFF
--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -158,22 +158,29 @@ export function findTargetClassNameNodes(
         ) {
           keywordStartingNodes.push(currentASTNode);
 
-          // classNameNodes.forEach((classNameNode) => {
-          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          classNameNodes.forEach((classNameNode, index, array) => {
+            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-          //   if (
-          //     currentNodeRangeStart <= classNameRangeStart &&
-          //     classNameRangeEnd <= currentNodeRangeEnd
-          //   ) {
-          //     if (
-          //       classNameNode.type === ClassNameType.USL ||
-          //       classNameNode.type === ClassNameType.UTL
-          //     ) {
-          //       // eslint-disable-next-line no-param-reassign
-          //       classNameNode.type = ClassNameType.FA;
-          //     }
-          //   }
-          // });
+            if (
+              currentNodeRangeStart <= classNameRangeStart &&
+              classNameRangeEnd <= currentNodeRangeEnd
+            ) {
+              if (classNameNode.type === 'unknown') {
+                // eslint-disable-next-line no-param-reassign
+                array[index] = {
+                  type: 'expression',
+                  delimiterType: classNameNode.delimiterType,
+                  isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+                  isItAnObjectProperty: false,
+                  isItAnOperandOfTernaryOperator: false,
+                  isItFunctionArgument: true,
+                  shouldKeepDelimiter: false,
+                  range: classNameNode.range,
+                  startLineIndex: classNameNode.startLineIndex,
+                };
+              }
+            }
+          });
         }
         break;
       }
@@ -279,25 +286,45 @@ export function findTargetClassNameNodes(
         ) {
           const currentNodeStartLineIndex = node.loc.start.line - 1;
 
-          // classNameNodes.forEach((classNameNode) => {
-          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          classNameNodes.forEach((classNameNode, index, array) => {
+            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-          //   if (
-          //     currentNodeRangeStart <= classNameRangeStart &&
-          //     classNameRangeEnd <= currentNodeRangeEnd
-          //   ) {
-          //     if (classNameNode.type === ClassNameType.USL) {
-          //       // eslint-disable-next-line no-param-reassign
-          //       classNameNode.type = ClassNameType.CSL;
-          //     } else if (classNameNode.type === ClassNameType.UTL) {
-          //       // eslint-disable-next-line no-param-reassign
-          //       classNameNode.type =
-          //         classNameNode.startLineIndex === currentNodeStartLineIndex
-          //           ? ClassNameType.TLSL
-          //           : ClassNameType.CTL;
-          //     }
-          //   }
-          // });
+            if (
+              currentNodeRangeStart <= classNameRangeStart &&
+              classNameRangeEnd <= currentNodeRangeEnd
+            ) {
+              if (classNameNode.type === 'unknown') {
+                if (classNameNode.delimiterType !== 'backtick') {
+                  // eslint-disable-next-line no-param-reassign
+                  array[index] = {
+                    type: 'expression',
+                    delimiterType: classNameNode.delimiterType,
+                    isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+                    isItAnObjectProperty: false,
+                    isItAnOperandOfTernaryOperator: false,
+                    isItFunctionArgument: false,
+                    shouldKeepDelimiter: false,
+                    range: classNameNode.range,
+                    startLineIndex: classNameNode.startLineIndex,
+                  };
+                } else {
+                  // eslint-disable-next-line no-param-reassign
+                  array[index] = {
+                    type: 'expression',
+                    delimiterType: classNameNode.delimiterType,
+                    isTheFirstLineOnTheSameLineAsTheAttributeName:
+                      classNameNode.startLineIndex === currentNodeStartLineIndex,
+                    isItAnObjectProperty: false,
+                    isItAnOperandOfTernaryOperator: false,
+                    isItFunctionArgument: false,
+                    shouldKeepDelimiter: false,
+                    range: classNameNode.range,
+                    startLineIndex: classNameNode.startLineIndex,
+                  };
+                }
+              }
+            }
+          });
         }
         break;
       }
@@ -305,46 +332,62 @@ export function findTargetClassNameNodes(
       case 'Property': {
         nonCommentNodes.push(currentASTNode);
 
-        // classNameNodes.forEach((classNameNode) => {
-        //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+        classNameNodes.forEach((classNameNode, index, array) => {
+          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-        //   if (
-        //     currentNodeRangeStart <= classNameRangeStart &&
-        //     classNameRangeEnd <= currentNodeRangeEnd
-        //   ) {
-        //     if (classNameNode.type === ClassNameType.USL) {
-        //       // eslint-disable-next-line no-param-reassign
-        //       classNameNode.type = ClassNameType.SLOP;
-        //     } else if (classNameNode.type === ClassNameType.UTL) {
-        //       // eslint-disable-next-line no-param-reassign
-        //       classNameNode.type = ClassNameType.TLOP;
-        //     }
-        //   }
-        // });
+          if (
+            currentNodeRangeStart <= classNameRangeStart &&
+            classNameRangeEnd <= currentNodeRangeEnd
+          ) {
+            if (classNameNode.type === 'unknown') {
+              // eslint-disable-next-line no-param-reassign
+              array[index] = {
+                type: 'expression',
+                delimiterType: classNameNode.delimiterType,
+                isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+                isItAnObjectProperty: true,
+                isItAnOperandOfTernaryOperator: false,
+                isItFunctionArgument: false,
+                shouldKeepDelimiter: false,
+                range: classNameNode.range,
+                startLineIndex: classNameNode.startLineIndex,
+              };
+            }
+          }
+        });
         break;
       }
       case 'ConditionalExpression': {
         nonCommentNodes.push(currentASTNode);
 
-        // classNameNodes.forEach((classNameNode) => {
-        //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+        classNameNodes.forEach((classNameNode, index, array) => {
+          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-        //   if (
-        //     currentNodeRangeStart <= classNameRangeStart &&
-        //     classNameRangeEnd <= currentNodeRangeEnd
-        //   ) {
-        //     if (classNameNode.type === ClassNameType.USL) {
-        //       // eslint-disable-next-line no-param-reassign
-        //       classNameNode.type = ClassNameType.SLTO;
-        //     } else if (classNameNode.type === ClassNameType.UTL) {
-        //       // eslint-disable-next-line no-param-reassign
-        //       classNameNode.type = ClassNameType.TLTO;
-        //     } else if (classNameNode.type === ClassNameType.TLPQ) {
-        //       // eslint-disable-next-line no-param-reassign
-        //       classNameNode.type = ClassNameType.TLPQTO;
-        //     }
-        //   }
-        // });
+          if (
+            currentNodeRangeStart <= classNameRangeStart &&
+            classNameRangeEnd <= currentNodeRangeEnd
+          ) {
+            if (classNameNode.type === 'unknown') {
+              // eslint-disable-next-line no-param-reassign
+              array[index] = {
+                type: 'expression',
+                delimiterType: classNameNode.delimiterType,
+                isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+                isItAnObjectProperty: false,
+                isItAnOperandOfTernaryOperator: true,
+                isItFunctionArgument: false,
+                shouldKeepDelimiter: false,
+                range: classNameNode.range,
+                startLineIndex: classNameNode.startLineIndex,
+              };
+            } else if (classNameNode.type === 'expression') {
+              if (classNameNode.delimiterType === 'backtick' && classNameNode.shouldKeepDelimiter) {
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.isItAnOperandOfTernaryOperator = true;
+              }
+            }
+          }
+        });
         break;
       }
       case 'Literal': {
@@ -442,11 +485,26 @@ export function findTargetClassNameNodes(
             (options.singleQuote && cooked.indexOf("'") !== -1) ||
             (!options.singleQuote && cooked.indexOf('"') !== -1);
 
-          // classNameNodes.push({
-          //   type: conditionForPreservation ? ClassNameType.TLPQ : ClassNameType.UTL,
-          //   range: [currentNodeRangeStart, currentNodeRangeEnd],
-          //   startLineIndex: node.loc.start.line - 1,
-          // });
+          if (conditionForPreservation) {
+            classNameNodes.push({
+              type: 'expression',
+              delimiterType: 'backtick',
+              isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+              isItAnObjectProperty: false,
+              isItAnOperandOfTernaryOperator: false,
+              isItFunctionArgument: false,
+              shouldKeepDelimiter: true,
+              range: [currentNodeRangeStart, currentNodeRangeEnd],
+              startLineIndex: node.loc.start.line - 1,
+            });
+          } else {
+            classNameNodes.push({
+              type: 'unknown',
+              delimiterType: 'backtick',
+              range: [currentNodeRangeStart, currentNodeRangeEnd],
+              startLineIndex: node.loc.start.line - 1,
+            });
+          }
         }
         break;
       }
@@ -493,19 +551,29 @@ export function findTargetClassNameNodes(
         ) {
           keywordStartingNodes.push(currentASTNode);
 
-          // classNameNodes.forEach((classNameNode) => {
-          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          classNameNodes.forEach((classNameNode, index, array) => {
+            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-          //   if (
-          //     currentNodeRangeStart <= classNameRangeStart &&
-          //     classNameRangeEnd <= currentNodeRangeEnd
-          //   ) {
-          //     if (classNameNode.type === ClassNameType.UTL) {
-          //       // eslint-disable-next-line no-param-reassign
-          //       classNameNode.type = ClassNameType.TLPQ;
-          //     }
-          //   }
-          // });
+            if (
+              currentNodeRangeStart <= classNameRangeStart &&
+              classNameRangeEnd <= currentNodeRangeEnd
+            ) {
+              if (classNameNode.type === 'unknown' && classNameNode.delimiterType === 'backtick') {
+                // eslint-disable-next-line no-param-reassign
+                array[index] = {
+                  type: 'expression',
+                  delimiterType: classNameNode.delimiterType,
+                  isTheFirstLineOnTheSameLineAsTheAttributeName: false,
+                  isItAnObjectProperty: false,
+                  isItAnOperandOfTernaryOperator: false,
+                  isItFunctionArgument: false,
+                  shouldKeepDelimiter: true,
+                  range: classNameNode.range,
+                  startLineIndex: classNameNode.startLineIndex,
+                };
+              }
+            }
+          });
         }
         break;
       }
@@ -702,31 +770,31 @@ export function findTargetClassNameNodesForVue(
                 const targetClassNameNodesInAttribute = findTargetClassNameNodes(
                   babelAst,
                   options,
-                ).map<ClassNameNode>(
-                  ({
-                    type,
-                    range: [classNameNodeRangeStart, classNameNodeRangeEnd],
-                    startLineIndex,
-                  }) => {
-                    // if (type === ClassNameType.CSL && startLineIndex === 0) {
-                    //   // eslint-disable-next-line no-param-reassign
-                    //   type = ClassNameType.SLSL;
-                    // }
+                ).map<ClassNameNode>((classNameNode) => {
+                  const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-                    const attributeOffset = -jsxStart.length + node.valueSpan.start.offset + 1;
+                  if (
+                    classNameNode.type === 'expression' &&
+                    classNameNode.delimiterType !== 'backtick' &&
+                    classNameNode.startLineIndex === 0
+                  ) {
+                    // eslint-disable-next-line no-param-reassign
+                    classNameNode.isTheFirstLineOnTheSameLineAsTheAttributeName = true;
+                  }
 
-                    return {
-                      type,
-                      range: [
-                        classNameNodeRangeStart + attributeOffset,
-                        classNameNodeRangeEnd + attributeOffset,
-                      ],
-                      startLineIndex: startLineIndex + node.sourceSpan.start.line,
-                    };
-                  },
-                );
+                  const attributeOffset = -jsxStart.length + node.valueSpan.start.offset + 1;
 
-                // classNameNodes.push(...targetClassNameNodesInAttribute);
+                  return {
+                    ...classNameNode,
+                    range: [
+                      classNameRangeStart + attributeOffset,
+                      classNameRangeEnd + attributeOffset,
+                    ],
+                    startLineIndex: classNameNode.startLineIndex + node.sourceSpan.start.line,
+                  };
+                });
+
+                classNameNodes.push(...targetClassNameNodesInAttribute);
               } catch (error) {
                 // no action
               }
@@ -793,26 +861,19 @@ export function findTargetClassNameNodesForVue(
             const targetClassNameNodesInScript = findTargetClassNameNodes(
               typescriptAst,
               options,
-            ).map<ClassNameNode>(
-              ({
-                type,
-                range: [classNameNodeRangeStart, classNameNodeRangeEnd],
-                startLineIndex,
-              }) => {
-                const scriptOffset = node.startSourceSpan.end.offset;
+            ).map<ClassNameNode>((classNameNode) => {
+              const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-                return {
-                  type,
-                  range: [
-                    classNameNodeRangeStart + scriptOffset,
-                    classNameNodeRangeEnd + scriptOffset,
-                  ],
-                  startLineIndex: startLineIndex + node.sourceSpan.start.line,
-                };
-              },
-            );
+              const scriptOffset = node.startSourceSpan.end.offset;
 
-            // classNameNodes.push(...targetClassNameNodesInScript);
+              return {
+                ...classNameNode,
+                range: [classNameRangeStart + scriptOffset, classNameRangeEnd + scriptOffset],
+                startLineIndex: classNameNode.startLineIndex + node.sourceSpan.start.line,
+              };
+            });
+
+            classNameNodes.push(...targetClassNameNodesInScript);
           }
         }
         break;
@@ -972,26 +1033,22 @@ export function findTargetClassNameNodesForAstro(
               ...options,
               customAttributes: supportedAttributes,
               customFunctions: supportedFunctions,
-            }).map<ClassNameNode>(
-              ({
-                type,
-                range: [classNameNodeRangeStart, classNameNodeRangeEnd],
-                startLineIndex,
-              }) => {
-                const frontMatterOffset = '---'.length;
+            }).map<ClassNameNode>((classNameNode) => {
+              const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-                return {
-                  type,
-                  range: [
-                    classNameNodeRangeStart + frontMatterOffset,
-                    classNameNodeRangeEnd + frontMatterOffset,
-                  ],
-                  startLineIndex,
-                };
-              },
-            );
+              const frontMatterOffset = '---'.length;
 
-            // classNameNodes.push(...targetClassNameNodesInFrontMatter);
+              return {
+                ...classNameNode,
+                range: [
+                  classNameRangeStart + frontMatterOffset,
+                  classNameRangeEnd + frontMatterOffset,
+                ],
+                startLineIndex: classNameNode.startLineIndex,
+              };
+            });
+
+            classNameNodes.push(...targetClassNameNodesInFrontMatter);
           }
         }
         break;
@@ -1039,32 +1096,32 @@ export function findTargetClassNameNodesForAstro(
                 ...options,
                 customAttributes: supportedAttributes,
                 customFunctions: supportedFunctions,
-              }).map<ClassNameNode>(
-                ({
-                  type,
-                  range: [classNameNodeRangeStart, classNameNodeRangeEnd],
-                  startLineIndex,
-                }) => {
-                  // if (type === ClassNameType.CSL && startLineIndex === 0) {
-                  //   // eslint-disable-next-line no-param-reassign
-                  //   type = ClassNameType.SLSL;
-                  // }
+              }).map<ClassNameNode>((classNameNode) => {
+                const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
-                  const attributeOffset =
-                    -jsxStart.length + currentNodeRangeStart + attributeStart.length;
+                if (
+                  classNameNode.type === 'expression' &&
+                  classNameNode.delimiterType !== 'backtick' &&
+                  classNameNode.startLineIndex === 0
+                ) {
+                  // eslint-disable-next-line no-param-reassign
+                  classNameNode.isTheFirstLineOnTheSameLineAsTheAttributeName = true;
+                }
 
-                  return {
-                    type,
-                    range: [
-                      classNameNodeRangeStart + attributeOffset,
-                      classNameNodeRangeEnd + attributeOffset,
-                    ],
-                    startLineIndex: startLineIndex + node.position.start.line - 1,
-                  };
-                },
-              );
+                const attributeOffset =
+                  -jsxStart.length + currentNodeRangeStart + attributeStart.length;
 
-              // classNameNodes.push(...targetClassNameNodesInAttribute);
+                return {
+                  ...classNameNode,
+                  range: [
+                    classNameNodeRangeStart + attributeOffset,
+                    classNameNodeRangeEnd + attributeOffset,
+                  ],
+                  startLineIndex: classNameNode.startLineIndex + node.position.start.line - 1,
+                };
+              });
+
+              classNameNodes.push(...targetClassNameNodesInAttribute);
             }
           } else if (node.kind === 'quoted') {
             const classNameRangeStart = currentNodeRangeStart + attributeStart.length - 1;

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -2,7 +2,7 @@ import type { ZodTypeAny, infer as ZodInfer } from 'zod';
 import { z } from 'zod';
 
 import type { Dict, NodeRange, ClassNameNode, NarrowedParserOptions } from './shared';
-import { EOL, ClassNameType } from './shared';
+import { EOL } from './shared';
 
 type ASTNode = {
   type: string;
@@ -158,22 +158,22 @@ export function findTargetClassNameNodes(
         ) {
           keywordStartingNodes.push(currentASTNode);
 
-          classNameNodes.forEach((classNameNode) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          // classNameNodes.forEach((classNameNode) => {
+          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-            if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
-            ) {
-              if (
-                classNameNode.type === ClassNameType.USL ||
-                classNameNode.type === ClassNameType.UTL
-              ) {
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.type = ClassNameType.FA;
-              }
-            }
-          });
+          //   if (
+          //     currentNodeRangeStart <= classNameRangeStart &&
+          //     classNameRangeEnd <= currentNodeRangeEnd
+          //   ) {
+          //     if (
+          //       classNameNode.type === ClassNameType.USL ||
+          //       classNameNode.type === ClassNameType.UTL
+          //     ) {
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.type = ClassNameType.FA;
+          //     }
+          //   }
+          // });
         }
         break;
       }
@@ -236,27 +236,27 @@ export function findTargetClassNameNodes(
           const parentNodeStartLineNumber = parentNode.loc.start.line;
           const currentNodeStartLineNumber = node.loc.start.line;
 
-          classNameNodes.forEach((classNameNode) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          // classNameNodes.forEach((classNameNode) => {
+          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-            if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
-            ) {
-              if (classNameNode.type === ClassNameType.USL) {
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.type =
-                  parentNodeStartLineNumber === currentNodeStartLineNumber
-                    ? ClassNameType.ASL
-                    : ClassNameType.AOL;
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.elementName = getElementName(
-                  // @ts-ignore
-                  parentNode.name,
-                );
-              }
-            }
-          });
+          //   if (
+          //     currentNodeRangeStart <= classNameRangeStart &&
+          //     classNameRangeEnd <= currentNodeRangeEnd
+          //   ) {
+          //     if (classNameNode.type === ClassNameType.USL) {
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.type =
+          //         parentNodeStartLineNumber === currentNodeStartLineNumber
+          //           ? ClassNameType.ASL
+          //           : ClassNameType.AOL;
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.elementName = getElementName(
+          //         // @ts-ignore
+          //         parentNode.name,
+          //       );
+          //     }
+          //   }
+          // });
         }
         break;
       }
@@ -277,25 +277,25 @@ export function findTargetClassNameNodes(
         ) {
           const currentNodeStartLineIndex = node.loc.start.line - 1;
 
-          classNameNodes.forEach((classNameNode) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          // classNameNodes.forEach((classNameNode) => {
+          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-            if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
-            ) {
-              if (classNameNode.type === ClassNameType.USL) {
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.type = ClassNameType.CSL;
-              } else if (classNameNode.type === ClassNameType.UTL) {
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.type =
-                  classNameNode.startLineIndex === currentNodeStartLineIndex
-                    ? ClassNameType.TLSL
-                    : ClassNameType.CTL;
-              }
-            }
-          });
+          //   if (
+          //     currentNodeRangeStart <= classNameRangeStart &&
+          //     classNameRangeEnd <= currentNodeRangeEnd
+          //   ) {
+          //     if (classNameNode.type === ClassNameType.USL) {
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.type = ClassNameType.CSL;
+          //     } else if (classNameNode.type === ClassNameType.UTL) {
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.type =
+          //         classNameNode.startLineIndex === currentNodeStartLineIndex
+          //           ? ClassNameType.TLSL
+          //           : ClassNameType.CTL;
+          //     }
+          //   }
+          // });
         }
         break;
       }
@@ -303,46 +303,46 @@ export function findTargetClassNameNodes(
       case 'Property': {
         nonCommentNodes.push(currentASTNode);
 
-        classNameNodes.forEach((classNameNode) => {
-          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+        // classNameNodes.forEach((classNameNode) => {
+        //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-          if (
-            currentNodeRangeStart <= classNameRangeStart &&
-            classNameRangeEnd <= currentNodeRangeEnd
-          ) {
-            if (classNameNode.type === ClassNameType.USL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.SLOP;
-            } else if (classNameNode.type === ClassNameType.UTL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.TLOP;
-            }
-          }
-        });
+        //   if (
+        //     currentNodeRangeStart <= classNameRangeStart &&
+        //     classNameRangeEnd <= currentNodeRangeEnd
+        //   ) {
+        //     if (classNameNode.type === ClassNameType.USL) {
+        //       // eslint-disable-next-line no-param-reassign
+        //       classNameNode.type = ClassNameType.SLOP;
+        //     } else if (classNameNode.type === ClassNameType.UTL) {
+        //       // eslint-disable-next-line no-param-reassign
+        //       classNameNode.type = ClassNameType.TLOP;
+        //     }
+        //   }
+        // });
         break;
       }
       case 'ConditionalExpression': {
         nonCommentNodes.push(currentASTNode);
 
-        classNameNodes.forEach((classNameNode) => {
-          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+        // classNameNodes.forEach((classNameNode) => {
+        //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-          if (
-            currentNodeRangeStart <= classNameRangeStart &&
-            classNameRangeEnd <= currentNodeRangeEnd
-          ) {
-            if (classNameNode.type === ClassNameType.USL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.SLTO;
-            } else if (classNameNode.type === ClassNameType.UTL) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.TLTO;
-            } else if (classNameNode.type === ClassNameType.TLPQ) {
-              // eslint-disable-next-line no-param-reassign
-              classNameNode.type = ClassNameType.TLPQTO;
-            }
-          }
-        });
+        //   if (
+        //     currentNodeRangeStart <= classNameRangeStart &&
+        //     classNameRangeEnd <= currentNodeRangeEnd
+        //   ) {
+        //     if (classNameNode.type === ClassNameType.USL) {
+        //       // eslint-disable-next-line no-param-reassign
+        //       classNameNode.type = ClassNameType.SLTO;
+        //     } else if (classNameNode.type === ClassNameType.UTL) {
+        //       // eslint-disable-next-line no-param-reassign
+        //       classNameNode.type = ClassNameType.TLTO;
+        //     } else if (classNameNode.type === ClassNameType.TLPQ) {
+        //       // eslint-disable-next-line no-param-reassign
+        //       classNameNode.type = ClassNameType.TLPQTO;
+        //     }
+        //   }
+        // });
         break;
       }
       case 'Literal': {
@@ -361,11 +361,11 @@ export function findTargetClassNameNodes(
             }),
           )
         ) {
-          classNameNodes.push({
-            type: ClassNameType.USL,
-            range: [currentNodeRangeStart, currentNodeRangeEnd],
-            startLineIndex: node.loc.start.line - 1,
-          });
+          // classNameNodes.push({
+          //   type: ClassNameType.USL,
+          //   range: [currentNodeRangeStart, currentNodeRangeEnd],
+          //   startLineIndex: node.loc.start.line - 1,
+          // });
         }
         break;
       }
@@ -384,11 +384,11 @@ export function findTargetClassNameNodes(
             }),
           )
         ) {
-          classNameNodes.push({
-            type: ClassNameType.USL,
-            range: [currentNodeRangeStart, currentNodeRangeEnd],
-            startLineIndex: node.loc.start.line - 1,
-          });
+          // classNameNodes.push({
+          //   type: ClassNameType.USL,
+          //   range: [currentNodeRangeStart, currentNodeRangeEnd],
+          //   startLineIndex: node.loc.start.line - 1,
+          // });
         }
         break;
       }
@@ -422,11 +422,11 @@ export function findTargetClassNameNodes(
             (options.singleQuote && cooked.indexOf("'") !== -1) ||
             (!options.singleQuote && cooked.indexOf('"') !== -1);
 
-          classNameNodes.push({
-            type: conditionForPreservation ? ClassNameType.TLPQ : ClassNameType.UTL,
-            range: [currentNodeRangeStart, currentNodeRangeEnd],
-            startLineIndex: node.loc.start.line - 1,
-          });
+          // classNameNodes.push({
+          //   type: conditionForPreservation ? ClassNameType.TLPQ : ClassNameType.UTL,
+          //   range: [currentNodeRangeStart, currentNodeRangeEnd],
+          //   startLineIndex: node.loc.start.line - 1,
+          // });
         }
         break;
       }
@@ -473,19 +473,19 @@ export function findTargetClassNameNodes(
         ) {
           keywordStartingNodes.push(currentASTNode);
 
-          classNameNodes.forEach((classNameNode) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          // classNameNodes.forEach((classNameNode) => {
+          //   const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
 
-            if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
-            ) {
-              if (classNameNode.type === ClassNameType.UTL) {
-                // eslint-disable-next-line no-param-reassign
-                classNameNode.type = ClassNameType.TLPQ;
-              }
-            }
-          });
+          //   if (
+          //     currentNodeRangeStart <= classNameRangeStart &&
+          //     classNameRangeEnd <= currentNodeRangeEnd
+          //   ) {
+          //     if (classNameNode.type === ClassNameType.UTL) {
+          //       // eslint-disable-next-line no-param-reassign
+          //       classNameNode.type = ClassNameType.TLPQ;
+          //     }
+          //   }
+          // });
         }
         break;
       }
@@ -687,10 +687,10 @@ export function findTargetClassNameNodesForVue(
                     range: [classNameNodeRangeStart, classNameNodeRangeEnd],
                     startLineIndex,
                   }) => {
-                    if (type === ClassNameType.CSL && startLineIndex === 0) {
-                      // eslint-disable-next-line no-param-reassign
-                      type = ClassNameType.SLSL;
-                    }
+                    // if (type === ClassNameType.CSL && startLineIndex === 0) {
+                    //   // eslint-disable-next-line no-param-reassign
+                    //   type = ClassNameType.SLSL;
+                    // }
 
                     const attributeOffset = -jsxStart.length + node.valueSpan.start.offset + 1;
 
@@ -705,7 +705,7 @@ export function findTargetClassNameNodesForVue(
                   },
                 );
 
-                classNameNodes.push(...targetClassNameNodesInAttribute);
+                // classNameNodes.push(...targetClassNameNodesInAttribute);
               } catch (error) {
                 // no action
               }
@@ -722,14 +722,14 @@ export function findTargetClassNameNodesForVue(
             const parentNodeStartLineIndex = parentNode.sourceSpan.start.line;
             const nodeStartLineIndex = node.sourceSpan.start.line;
 
-            classNameNodes.push({
-              type:
-                parentNodeStartLineIndex === nodeStartLineIndex
-                  ? ClassNameType.ASL
-                  : ClassNameType.AOL,
-              range: [classNameRangeStart, classNameRangeEnd],
-              startLineIndex: nodeStartLineIndex,
-            });
+            // classNameNodes.push({
+            //   type:
+            //     parentNodeStartLineIndex === nodeStartLineIndex
+            //       ? ClassNameType.ASL
+            //       : ClassNameType.AOL,
+            //   range: [classNameRangeStart, classNameRangeEnd],
+            //   startLineIndex: nodeStartLineIndex,
+            // });
           }
         }
         break;
@@ -791,7 +791,7 @@ export function findTargetClassNameNodesForVue(
               },
             );
 
-            classNameNodes.push(...targetClassNameNodesInScript);
+            // classNameNodes.push(...targetClassNameNodesInScript);
           }
         }
         break;
@@ -970,7 +970,7 @@ export function findTargetClassNameNodesForAstro(
               },
             );
 
-            classNameNodes.push(...targetClassNameNodesInFrontMatter);
+            // classNameNodes.push(...targetClassNameNodesInFrontMatter);
           }
         }
         break;
@@ -1023,10 +1023,10 @@ export function findTargetClassNameNodesForAstro(
                   range: [classNameNodeRangeStart, classNameNodeRangeEnd],
                   startLineIndex,
                 }) => {
-                  if (type === ClassNameType.CSL && startLineIndex === 0) {
-                    // eslint-disable-next-line no-param-reassign
-                    type = ClassNameType.SLSL;
-                  }
+                  // if (type === ClassNameType.CSL && startLineIndex === 0) {
+                  //   // eslint-disable-next-line no-param-reassign
+                  //   type = ClassNameType.SLSL;
+                  // }
 
                   const attributeOffset =
                     -jsxStart.length + currentNodeRangeStart + attributeStart.length;
@@ -1042,7 +1042,7 @@ export function findTargetClassNameNodesForAstro(
                 },
               );
 
-              classNameNodes.push(...targetClassNameNodesInAttribute);
+              // classNameNodes.push(...targetClassNameNodesInAttribute);
             }
           } else if (node.kind === 'quoted') {
             const classNameRangeStart = currentNodeRangeStart + attributeStart.length - 1;
@@ -1051,14 +1051,14 @@ export function findTargetClassNameNodesForAstro(
             const parentNodeStartLineIndex = parentNode.position.start.line - 1;
             const nodeStartLineIndex = node.position.start.line - 1;
 
-            classNameNodes.push({
-              type:
-                parentNodeStartLineIndex === nodeStartLineIndex
-                  ? ClassNameType.ASL
-                  : ClassNameType.AOL,
-              range: [classNameRangeStart, classNameRangeEnd],
-              startLineIndex: node.position.start.line - 1,
-            });
+            // classNameNodes.push({
+            //   type:
+            //     parentNodeStartLineIndex === nodeStartLineIndex
+            //       ? ClassNameType.ASL
+            //       : ClassNameType.AOL,
+            //   range: [classNameRangeStart, classNameRangeEnd],
+            //   startLineIndex: node.position.start.line - 1,
+            // });
           }
         }
         break;

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -41,10 +41,13 @@ function filterAndSortClassNameNodes(
   classNameNodes: ClassNameNode[],
 ): ClassNameNode[] {
   const ignoreRanges = prettierIgnoreNodes.map(({ range }) => {
-    const [, prettierIgnoreRangeEnd] = range;
+    const [, prettierIgnoreNodeRangeEnd] = range;
 
     const ignoringNodeOrNot = nonCommentNodes
-      .filter(({ range: [nonCommentRangeStart] }) => prettierIgnoreRangeEnd < nonCommentRangeStart)
+      .filter(
+        ({ range: [nonCommentNodeRangeStart] }) =>
+          prettierIgnoreNodeRangeEnd < nonCommentNodeRangeStart,
+      )
       .sort(
         (
           { range: [formerNodeRangeStart, formerNodeRangeEnd] },
@@ -59,15 +62,17 @@ function filterAndSortClassNameNodes(
 
   return classNameNodes
     .filter(
-      ({ range: [classNameRangeStart, classNameRangeEnd] }) =>
+      ({ range: [classNameNodeRangeStart, classNameNodeRangeEnd] }) =>
         ignoreRanges.every(
           ([ignoreRangeStart, ignoreRangeEnd]) =>
-            !(ignoreRangeStart <= classNameRangeStart && classNameRangeEnd <= ignoreRangeEnd),
+            !(
+              ignoreRangeStart <= classNameNodeRangeStart && classNameNodeRangeEnd <= ignoreRangeEnd
+            ),
         ) &&
         keywordStartingRanges.some(
           ([keywordStartingRangeStart, keywordStartingRangeEnd]) =>
-            keywordStartingRangeStart < classNameRangeStart &&
-            classNameRangeEnd <= keywordStartingRangeEnd,
+            keywordStartingRangeStart < classNameNodeRangeStart &&
+            classNameNodeRangeEnd <= keywordStartingRangeEnd,
         ),
     )
     .sort(
@@ -159,11 +164,11 @@ export function findTargetClassNameNodes(
           keywordStartingNodes.push(currentASTNode);
 
           classNameNodes.forEach((classNameNode, index, array) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+            const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
             if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
+              currentNodeRangeStart <= classNameNodeRangeStart &&
+              classNameNodeRangeEnd <= currentNodeRangeEnd
             ) {
               if (classNameNode.type === 'unknown') {
                 // eslint-disable-next-line no-param-reassign
@@ -244,11 +249,11 @@ export function findTargetClassNameNodes(
           const currentNodeStartLineNumber = node.loc.start.line;
 
           classNameNodes.forEach((classNameNode, index, array) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+            const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
             if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
+              currentNodeRangeStart <= classNameNodeRangeStart &&
+              classNameNodeRangeEnd <= currentNodeRangeEnd
             ) {
               if (classNameNode.type === 'unknown' && classNameNode.delimiterType !== 'backtick') {
                 // eslint-disable-next-line no-param-reassign
@@ -287,11 +292,11 @@ export function findTargetClassNameNodes(
           const currentNodeStartLineIndex = node.loc.start.line - 1;
 
           classNameNodes.forEach((classNameNode, index, array) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+            const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
             if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
+              currentNodeRangeStart <= classNameNodeRangeStart &&
+              classNameNodeRangeEnd <= currentNodeRangeEnd
             ) {
               if (classNameNode.type === 'unknown') {
                 if (classNameNode.delimiterType !== 'backtick') {
@@ -333,11 +338,11 @@ export function findTargetClassNameNodes(
         nonCommentNodes.push(currentASTNode);
 
         classNameNodes.forEach((classNameNode, index, array) => {
-          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
           if (
-            currentNodeRangeStart <= classNameRangeStart &&
-            classNameRangeEnd <= currentNodeRangeEnd
+            currentNodeRangeStart <= classNameNodeRangeStart &&
+            classNameNodeRangeEnd <= currentNodeRangeEnd
           ) {
             if (classNameNode.type === 'unknown') {
               // eslint-disable-next-line no-param-reassign
@@ -361,11 +366,11 @@ export function findTargetClassNameNodes(
         nonCommentNodes.push(currentASTNode);
 
         classNameNodes.forEach((classNameNode, index, array) => {
-          const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+          const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
           if (
-            currentNodeRangeStart <= classNameRangeStart &&
-            classNameRangeEnd <= currentNodeRangeEnd
+            currentNodeRangeStart <= classNameNodeRangeStart &&
+            classNameNodeRangeEnd <= currentNodeRangeEnd
           ) {
             if (classNameNode.type === 'unknown') {
               // eslint-disable-next-line no-param-reassign
@@ -552,11 +557,11 @@ export function findTargetClassNameNodes(
           keywordStartingNodes.push(currentASTNode);
 
           classNameNodes.forEach((classNameNode, index, array) => {
-            const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+            const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
             if (
-              currentNodeRangeStart <= classNameRangeStart &&
-              classNameRangeEnd <= currentNodeRangeEnd
+              currentNodeRangeStart <= classNameNodeRangeStart &&
+              classNameNodeRangeEnd <= currentNodeRangeEnd
             ) {
               if (classNameNode.type === 'unknown' && classNameNode.delimiterType === 'backtick') {
                 // eslint-disable-next-line no-param-reassign
@@ -771,7 +776,7 @@ export function findTargetClassNameNodesForVue(
                   babelAst,
                   options,
                 ).map<ClassNameNode>((classNameNode) => {
-                  const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+                  const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
                   if (
                     classNameNode.type === 'expression' &&
@@ -787,8 +792,8 @@ export function findTargetClassNameNodesForVue(
                   return {
                     ...classNameNode,
                     range: [
-                      classNameRangeStart + attributeOffset,
-                      classNameRangeEnd + attributeOffset,
+                      classNameNodeRangeStart + attributeOffset,
+                      classNameNodeRangeEnd + attributeOffset,
                     ],
                     startLineIndex: classNameNode.startLineIndex + node.sourceSpan.start.line,
                   };
@@ -800,12 +805,12 @@ export function findTargetClassNameNodesForVue(
               }
             }
           } else {
-            const classNameRangeStart = node.valueSpan.start.offset;
-            const classNameRangeEnd = node.valueSpan.end.offset;
+            const classNameNodeRangeStart = node.valueSpan.start.offset;
+            const classNameNodeRangeEnd = node.valueSpan.end.offset;
 
             nonCommentNodes.push({
               type: 'StringLiteral',
-              range: [classNameRangeStart, classNameRangeEnd],
+              range: [classNameNodeRangeStart, classNameNodeRangeEnd],
             });
 
             const parentNodeStartLineIndex = parentNode.sourceSpan.start.line;
@@ -816,7 +821,7 @@ export function findTargetClassNameNodesForVue(
               isTheFirstLineOnTheSameLineAsTheOpeningTag:
                 parentNodeStartLineIndex === nodeStartLineIndex,
               elementName: parentNode.name,
-              range: [classNameRangeStart, classNameRangeEnd],
+              range: [classNameNodeRangeStart, classNameNodeRangeEnd],
               startLineIndex: nodeStartLineIndex,
             });
           }
@@ -862,13 +867,16 @@ export function findTargetClassNameNodesForVue(
               typescriptAst,
               options,
             ).map<ClassNameNode>((classNameNode) => {
-              const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+              const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
               const scriptOffset = node.startSourceSpan.end.offset;
 
               return {
                 ...classNameNode,
-                range: [classNameRangeStart + scriptOffset, classNameRangeEnd + scriptOffset],
+                range: [
+                  classNameNodeRangeStart + scriptOffset,
+                  classNameNodeRangeEnd + scriptOffset,
+                ],
                 startLineIndex: classNameNode.startLineIndex + node.sourceSpan.start.line,
               };
             });
@@ -1034,15 +1042,15 @@ export function findTargetClassNameNodesForAstro(
               customAttributes: supportedAttributes,
               customFunctions: supportedFunctions,
             }).map<ClassNameNode>((classNameNode) => {
-              const [classNameRangeStart, classNameRangeEnd] = classNameNode.range;
+              const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
               const frontMatterOffset = '---'.length;
 
               return {
                 ...classNameNode,
                 range: [
-                  classNameRangeStart + frontMatterOffset,
-                  classNameRangeEnd + frontMatterOffset,
+                  classNameNodeRangeStart + frontMatterOffset,
+                  classNameNodeRangeEnd + frontMatterOffset,
                 ],
                 startLineIndex: classNameNode.startLineIndex,
               };
@@ -1124,9 +1132,6 @@ export function findTargetClassNameNodesForAstro(
               classNameNodes.push(...targetClassNameNodesInAttribute);
             }
           } else if (node.kind === 'quoted') {
-            const classNameRangeStart = currentNodeRangeStart + attributeStart.length - 1;
-            const classNameRangeEnd = currentNodeRangeEnd;
-
             const parentNodeStartLineIndex = parentNode.position.start.line - 1;
             const nodeStartLineIndex = node.position.start.line - 1;
 
@@ -1135,7 +1140,7 @@ export function findTargetClassNameNodesForAstro(
               isTheFirstLineOnTheSameLineAsTheOpeningTag:
                 parentNodeStartLineIndex === nodeStartLineIndex,
               elementName: parentNode.name,
-              range: [classNameRangeStart, classNameRangeEnd],
+              range: [currentNodeRangeStart + attributeStart.length - 1, currentNodeRangeEnd],
               startLineIndex: node.position.start.line - 1,
             });
           }

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -1152,12 +1152,11 @@ export function findTargetClassNameNodesForAstro(
           ) &&
           node.value.trim() === 'prettier-ignore'
         ) {
-          const [rangeStart, rangeEnd] = currentASTNode.range;
           const commentOffset = '<!--'.length;
 
           prettierIgnoreNodes.push({
             ...currentASTNode,
-            range: [rangeStart - commentOffset, rangeEnd],
+            range: [currentNodeRangeStart - commentOffset, currentNodeRangeEnd],
           });
         }
         break;

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -26,12 +26,11 @@ function parseLineByLine(formattedText: string, indentUnit: string): LineNode[] 
 }
 
 function getExtraIndentLevel(node: ClassNameNode) {
-  if (node.type === ClassNameType.ASL) {
-    return 2;
+  if (node.type === 'attribute') {
+    return node.isTheFirstLineOnTheSameLineAsTheOpeningTag ? 2 : 1;
   }
 
   if (
-    node.type === ClassNameType.AOL ||
     node.type === ClassNameType.SLSL ||
     node.type === ClassNameType.SLTO ||
     node.type === ClassNameType.TLSL ||
@@ -67,15 +66,11 @@ function getSomeKindOfQuotes(
       : '"';
 
   const opener = `${isMultiLineClassName && node.type === ClassNameType.SLOP ? '[' : ''}${
-    !isMultiLineClassName || node.type === ClassNameType.ASL || node.type === ClassNameType.AOL
-      ? baseQuote
-      : '`'
+    !isMultiLineClassName || node.type === 'attribute' ? baseQuote : '`'
   }`;
-  const closer = `${
-    !isMultiLineClassName || node.type === ClassNameType.ASL || node.type === ClassNameType.AOL
-      ? baseQuote
-      : '`'
-  }${isMultiLineClassName && node.type === ClassNameType.SLOP ? ']' : ''}`;
+  const closer = `${!isMultiLineClassName || node.type === 'attribute' ? baseQuote : '`'}${
+    isMultiLineClassName && node.type === ClassNameType.SLOP ? ']' : ''
+  }`;
 
   return [opener, closer];
 }
@@ -165,15 +160,9 @@ function replaceClassName({
 
       if (
         isSecondPhase &&
-        (((options.parser === 'vue' || options.parser === 'astro') &&
-          !(type === ClassNameType.ASL || type === ClassNameType.AOL)) ||
+        (((options.parser === 'vue' || options.parser === 'astro') && !(type === 'attribute')) ||
           (!(options.parser === 'vue' || options.parser === 'astro') &&
-            !(
-              type === ClassNameType.ASL ||
-              type === ClassNameType.AOL ||
-              type === ClassNameType.CTL ||
-              type === ClassNameType.TLSL
-            )))
+            !(type === 'attribute' || type === ClassNameType.CTL || type === ClassNameType.TLSL)))
       ) {
         return formattedPrevText;
       }
@@ -271,7 +260,8 @@ function replaceClassName({
       const spaceAfterElementName = ' ';
       const conditionForSameLineAttribute =
         isEndingPositionAbsolute &&
-        type === ClassNameType.ASL &&
+        type === 'attribute' &&
+        classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         isMultiLineClassName &&
         formattedClassName.length +
           options.tabWidth -
@@ -279,7 +269,8 @@ function replaceClassName({
           options.printWidth;
       const conditionForOwnLineAttribute =
         isEndingPositionAbsolute &&
-        type === ClassNameType.AOL &&
+        type === 'attribute' &&
+        !classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         !isMultiLineClassName &&
         classNameWithOriginalSpaces !== classNameBase &&
         formattedClassName.length -
@@ -290,7 +281,7 @@ function replaceClassName({
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
 
-      const isAttributeType = type === ClassNameType.ASL || type === ClassNameType.AOL;
+      const isAttributeType = type === 'attribute';
       const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
         isAttributeType ? '' : quoteEnd
       }`
@@ -449,15 +440,9 @@ async function replaceClassNameAsync({
 
       if (
         isSecondPhase &&
-        (((options.parser === 'vue' || options.parser === 'astro') &&
-          !(type === ClassNameType.ASL || type === ClassNameType.AOL)) ||
+        (((options.parser === 'vue' || options.parser === 'astro') && !(type === 'attribute')) ||
           (!(options.parser === 'vue' || options.parser === 'astro') &&
-            !(
-              type === ClassNameType.ASL ||
-              type === ClassNameType.AOL ||
-              type === ClassNameType.CTL ||
-              type === ClassNameType.TLSL
-            )))
+            !(type === 'attribute' || type === ClassNameType.CTL || type === ClassNameType.TLSL)))
       ) {
         return formattedPrevTextPromise;
       }
@@ -561,7 +546,8 @@ async function replaceClassNameAsync({
       const spaceAfterElementName = ' ';
       const conditionForSameLineAttribute =
         isEndingPositionAbsolute &&
-        type === ClassNameType.ASL &&
+        type === 'attribute' &&
+        classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         isMultiLineClassName &&
         formattedClassName.length +
           options.tabWidth -
@@ -569,7 +555,8 @@ async function replaceClassNameAsync({
           options.printWidth;
       const conditionForOwnLineAttribute =
         isEndingPositionAbsolute &&
-        type === ClassNameType.AOL &&
+        type === 'attribute' &&
+        !classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         !isMultiLineClassName &&
         classNameWithOriginalSpaces !== classNameBase &&
         formattedClassName.length -
@@ -580,7 +567,7 @@ async function replaceClassNameAsync({
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
 
-      const isAttributeType = type === ClassNameType.ASL || type === ClassNameType.AOL;
+      const isAttributeType = type === 'attribute';
       const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
         isAttributeType ? '' : quoteEnd
       }`

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -31,14 +31,12 @@ function getExtraIndentLevel(type: ClassNameType) {
   }
 
   if (
-    [
-      ClassNameType.AOL,
-      ClassNameType.SLSL,
-      ClassNameType.SLTO,
-      ClassNameType.TLSL,
-      ClassNameType.TLTO,
-      ClassNameType.TLPQTO,
-    ].includes(type)
+    type === ClassNameType.AOL ||
+    type === ClassNameType.SLSL ||
+    type === ClassNameType.SLTO ||
+    type === ClassNameType.TLSL ||
+    type === ClassNameType.TLTO ||
+    type === ClassNameType.TLPQTO
   ) {
     return 1;
   }
@@ -51,28 +49,22 @@ function getSomeKindOfQuotes(
   isMultiLineClassName: boolean,
   parser: string,
 ): [string, string] {
-  // prettier-ignore
   const baseQuote =
     // eslint-disable-next-line no-nested-ternary
     type === ClassNameType.TLPQ || type === ClassNameType.TLPQTO
       ? '`'
-      : (
-        parser === 'vue' &&
-        [
-          ClassNameType.FA,
-          ClassNameType.CSL,
-          ClassNameType.SLSL,
-          ClassNameType.SLOP,
-          ClassNameType.SLTO,
-          ClassNameType.CTL,
-          ClassNameType.TLSL,
-          ClassNameType.TLOP,
-          ClassNameType.TLTO,
-          ClassNameType.TLPQTO,
-        ].includes(type)
-          ? "'"
-          : '"'
-      );
+      : parser === 'vue' &&
+        (type === ClassNameType.FA ||
+          type === ClassNameType.CSL ||
+          type === ClassNameType.SLSL ||
+          type === ClassNameType.SLOP ||
+          type === ClassNameType.SLTO ||
+          type === ClassNameType.CTL ||
+          type === ClassNameType.TLSL ||
+          type === ClassNameType.TLOP ||
+          type === ClassNameType.TLTO)
+      ? "'"
+      : '"';
 
   const opener = `${isMultiLineClassName && type === ClassNameType.SLOP ? '[' : ''}${
     !isMultiLineClassName || type === ClassNameType.ASL || type === ClassNameType.AOL
@@ -170,11 +162,15 @@ function replaceClassName({
     ) => {
       if (
         isSecondPhase &&
-        !(
-          options.parser === 'vue' || options.parser === 'astro'
-            ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL]
-        ).includes(type)
+        (((options.parser === 'vue' || options.parser === 'astro') &&
+          !(type === ClassNameType.ASL || type === ClassNameType.AOL)) ||
+          (!(options.parser === 'vue' || options.parser === 'astro') &&
+            !(
+              type === ClassNameType.ASL ||
+              type === ClassNameType.AOL ||
+              type === ClassNameType.CTL ||
+              type === ClassNameType.TLSL
+            )))
       ) {
         return formattedPrevText;
       }
@@ -447,11 +443,15 @@ async function replaceClassNameAsync({
     ) => {
       if (
         isSecondPhase &&
-        !(
-          options.parser === 'vue' || options.parser === 'astro'
-            ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL]
-        ).includes(type)
+        (((options.parser === 'vue' || options.parser === 'astro') &&
+          !(type === ClassNameType.ASL || type === ClassNameType.AOL)) ||
+          (!(options.parser === 'vue' || options.parser === 'astro') &&
+            !(
+              type === ClassNameType.ASL ||
+              type === ClassNameType.AOL ||
+              type === ClassNameType.CTL ||
+              type === ClassNameType.TLSL
+            )))
       ) {
         return formattedPrevTextPromise;
       }

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -149,20 +149,16 @@ function replaceClassName({
 
   const icedFormattedText = targetClassNameNodes.reduce(
     (formattedPrevText, classNameNode, classNameNodeIndex) => {
-      const {
-        type,
-        range: [rangeStart, rangeEnd],
-        startLineIndex,
-        elementName,
-      } = classNameNode;
+      const [rangeStart, rangeEnd] = classNameNode.range;
 
       if (
         isSecondPhase &&
-        (((options.parser === 'vue' || options.parser === 'astro') && !(type === 'attribute')) ||
+        (((options.parser === 'vue' || options.parser === 'astro') &&
+          !(classNameNode.type === 'attribute')) ||
           (!(options.parser === 'vue' || options.parser === 'astro') &&
             !(
-              type === 'attribute' ||
-              (type === 'expression' &&
+              classNameNode.type === 'attribute' ||
+              (classNameNode.type === 'expression' &&
                 classNameNode.delimiterType === 'backtick' &&
                 !classNameNode.isItAnObjectProperty &&
                 !classNameNode.isItAnOperandOfTernaryOperator &&
@@ -179,7 +175,7 @@ function replaceClassName({
       const isEndingPositionAbsolute = options.endingPosition !== 'relative';
       const isOutputIdeal = isStartingPositionRelative && isEndingPositionAbsolute;
 
-      const { indentLevel: baseIndentLevel } = lineNodes[startLineIndex];
+      const { indentLevel: baseIndentLevel } = lineNodes[classNameNode.startLineIndex];
       const extraIndentLevel = getExtraIndentLevel(classNameNode);
       const multiLineIndentLevel = isStartingPositionRelative
         ? baseIndentLevel + extraIndentLevel
@@ -193,7 +189,7 @@ function replaceClassName({
 
       const totalTextLengthUptoPrevLine = formattedPrevText
         .split(EOL)
-        .slice(0, startLineIndex)
+        .slice(0, classNameNode.startLineIndex)
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
       const firstLineIndentLength = indentUnit.length * baseIndentLevel;
       const firstLinePadLength =
@@ -266,28 +262,28 @@ function replaceClassName({
       const spaceAfterElementName = ' ';
       const conditionForSameLineAttribute =
         isEndingPositionAbsolute &&
-        type === 'attribute' &&
+        classNameNode.type === 'attribute' &&
         classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         isMultiLineClassName &&
         formattedClassName.length +
           options.tabWidth -
-          (elementName ? `${elementOpener}${elementName}${spaceAfterElementName}`.length : 0) <=
+          `${elementOpener}${classNameNode.elementName}${spaceAfterElementName}`.length <=
           options.printWidth;
       const conditionForOwnLineAttribute =
         isEndingPositionAbsolute &&
-        type === 'attribute' &&
+        classNameNode.type === 'attribute' &&
         !classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         !isMultiLineClassName &&
         classNameWithOriginalSpaces !== classNameBase &&
         formattedClassName.length -
           options.tabWidth +
-          (elementName ? `${elementOpener}${elementName}${spaceAfterElementName}`.length : 0) >
+          `${elementOpener}${classNameNode.elementName}${spaceAfterElementName}`.length >
           options.printWidth;
 
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
 
-      const isAttributeType = type === 'attribute';
+      const isAttributeType = classNameNode.type === 'attribute';
       const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
         isAttributeType ? '' : quoteEnd
       }`
@@ -315,7 +311,7 @@ function replaceClassName({
 
       const sliceOffset =
         !isMultiLineClassName &&
-        type === 'expression' &&
+        classNameNode.type === 'expression' &&
         classNameNode.delimiterType === 'backtick' &&
         classNameNode.isItAnObjectProperty
           ? 1
@@ -443,20 +439,16 @@ async function replaceClassNameAsync({
 
   const icedFormattedText = await targetClassNameNodes.reduce(
     async (formattedPrevTextPromise, classNameNode, classNameNodeIndex) => {
-      const {
-        type,
-        range: [rangeStart, rangeEnd],
-        startLineIndex,
-        elementName,
-      } = classNameNode;
+      const [rangeStart, rangeEnd] = classNameNode.range;
 
       if (
         isSecondPhase &&
-        (((options.parser === 'vue' || options.parser === 'astro') && !(type === 'attribute')) ||
+        (((options.parser === 'vue' || options.parser === 'astro') &&
+          !(classNameNode.type === 'attribute')) ||
           (!(options.parser === 'vue' || options.parser === 'astro') &&
             !(
-              type === 'attribute' ||
-              (type === 'expression' &&
+              classNameNode.type === 'attribute' ||
+              (classNameNode.type === 'expression' &&
                 classNameNode.delimiterType === 'backtick' &&
                 !classNameNode.isItAnObjectProperty &&
                 !classNameNode.isItAnOperandOfTernaryOperator &&
@@ -475,7 +467,7 @@ async function replaceClassNameAsync({
       const isEndingPositionAbsolute = options.endingPosition !== 'relative';
       const isOutputIdeal = isStartingPositionRelative && isEndingPositionAbsolute;
 
-      const { indentLevel: baseIndentLevel } = lineNodes[startLineIndex];
+      const { indentLevel: baseIndentLevel } = lineNodes[classNameNode.startLineIndex];
       const extraIndentLevel = getExtraIndentLevel(classNameNode);
       const multiLineIndentLevel = isStartingPositionRelative
         ? baseIndentLevel + extraIndentLevel
@@ -489,7 +481,7 @@ async function replaceClassNameAsync({
 
       const totalTextLengthUptoPrevLine = formattedPrevText
         .split(EOL)
-        .slice(0, startLineIndex)
+        .slice(0, classNameNode.startLineIndex)
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
       const firstLineIndentLength = indentUnit.length * baseIndentLevel;
       const firstLinePadLength =
@@ -566,28 +558,28 @@ async function replaceClassNameAsync({
       const spaceAfterElementName = ' ';
       const conditionForSameLineAttribute =
         isEndingPositionAbsolute &&
-        type === 'attribute' &&
+        classNameNode.type === 'attribute' &&
         classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         isMultiLineClassName &&
         formattedClassName.length +
           options.tabWidth -
-          (elementName ? `${elementOpener}${elementName}${spaceAfterElementName}`.length : 0) <=
+          `${elementOpener}${classNameNode.elementName}${spaceAfterElementName}`.length <=
           options.printWidth;
       const conditionForOwnLineAttribute =
         isEndingPositionAbsolute &&
-        type === 'attribute' &&
+        classNameNode.type === 'attribute' &&
         !classNameNode.isTheFirstLineOnTheSameLineAsTheOpeningTag &&
         !isMultiLineClassName &&
         classNameWithOriginalSpaces !== classNameBase &&
         formattedClassName.length -
           options.tabWidth +
-          (elementName ? `${elementOpener}${elementName}${spaceAfterElementName}`.length : 0) >
+          `${elementOpener}${classNameNode.elementName}${spaceAfterElementName}`.length >
           options.printWidth;
 
       const rawIndent = indentUnit.repeat(multiLineIndentLevel);
       const frozenIndent = freezeNonClassName(rawIndent);
 
-      const isAttributeType = type === 'attribute';
+      const isAttributeType = classNameNode.type === 'attribute';
       const substitute = `${isAttributeType ? '' : quoteStart}${classNameWithOriginalSpaces}${
         isAttributeType ? '' : quoteEnd
       }`
@@ -615,7 +607,7 @@ async function replaceClassNameAsync({
 
       const sliceOffset =
         !isMultiLineClassName &&
-        type === 'expression' &&
+        classNameNode.type === 'expression' &&
         classNameNode.delimiterType === 'backtick' &&
         classNameNode.isItAnObjectProperty
           ? 1

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -149,7 +149,7 @@ function replaceClassName({
 
   const icedFormattedText = targetClassNameNodes.reduce(
     (formattedPrevText, classNameNode, classNameNodeIndex) => {
-      const [rangeStart, rangeEnd] = classNameNode.range;
+      const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
       if (
         isSecondPhase &&
@@ -169,7 +169,7 @@ function replaceClassName({
         return formattedPrevText;
       }
 
-      const correctedRangeEnd = rangeEnd - rangeCorrectionValues[classNameNodeIndex];
+      const correctedRangeEnd = classNameNodeRangeEnd - rangeCorrectionValues[classNameNodeIndex];
 
       const isStartingPositionRelative = options.endingPosition !== 'absolute';
       const isEndingPositionAbsolute = options.endingPosition !== 'relative';
@@ -181,7 +181,10 @@ function replaceClassName({
         ? baseIndentLevel + extraIndentLevel
         : 0;
 
-      const classNameBase = formattedPrevText.slice(rangeStart + 1, correctedRangeEnd - 1);
+      const classNameBase = formattedPrevText.slice(
+        classNameNodeRangeStart + 1,
+        correctedRangeEnd - 1,
+      );
 
       // preprocess (first)
       const [leadingSpace, classNameWithoutSpacesAtBothEnds, trailingSpace] =
@@ -193,7 +196,7 @@ function replaceClassName({
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
       const firstLineIndentLength = indentUnit.length * baseIndentLevel;
       const firstLinePadLength =
-        rangeStart +
+        classNameNodeRangeStart +
         1 -
         totalTextLengthUptoPrevLine -
         firstLineIndentLength +
@@ -318,7 +321,7 @@ function replaceClassName({
           : 0;
       const classNamePartialWrappedText = `${formattedPrevText.slice(
         0,
-        rangeStart - sliceOffset + (isAttributeType ? 1 : 0),
+        classNameNodeRangeStart - sliceOffset + (isAttributeType ? 1 : 0),
       )}${substitute}${
         isAttributeType
           ? formattedPrevText.slice(
@@ -340,9 +343,13 @@ function replaceClassName({
         const [nthNodeRangeStart, nthNodeRangeEnd] =
           targetClassNameNodes[rangeCorrectionIndex].range;
 
-        if (nthNodeRangeStart < rangeStart && rangeEnd < nthNodeRangeEnd) {
+        if (
+          nthNodeRangeStart < classNameNodeRangeStart &&
+          classNameNodeRangeEnd < nthNodeRangeEnd
+        ) {
           // eslint-disable-next-line no-param-reassign
-          array[rangeCorrectionIndex] += correctedRangeEnd - rangeStart - substitute.length;
+          array[rangeCorrectionIndex] +=
+            correctedRangeEnd - classNameNodeRangeStart - substitute.length;
         }
       });
 
@@ -439,7 +446,7 @@ async function replaceClassNameAsync({
 
   const icedFormattedText = await targetClassNameNodes.reduce(
     async (formattedPrevTextPromise, classNameNode, classNameNodeIndex) => {
-      const [rangeStart, rangeEnd] = classNameNode.range;
+      const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
 
       if (
         isSecondPhase &&
@@ -461,7 +468,7 @@ async function replaceClassNameAsync({
 
       const formattedPrevText = await formattedPrevTextPromise;
 
-      const correctedRangeEnd = rangeEnd - rangeCorrectionValues[classNameNodeIndex];
+      const correctedRangeEnd = classNameNodeRangeEnd - rangeCorrectionValues[classNameNodeIndex];
 
       const isStartingPositionRelative = options.endingPosition !== 'absolute';
       const isEndingPositionAbsolute = options.endingPosition !== 'relative';
@@ -473,7 +480,10 @@ async function replaceClassNameAsync({
         ? baseIndentLevel + extraIndentLevel
         : 0;
 
-      const classNameBase = formattedPrevText.slice(rangeStart + 1, correctedRangeEnd - 1);
+      const classNameBase = formattedPrevText.slice(
+        classNameNodeRangeStart + 1,
+        correctedRangeEnd - 1,
+      );
 
       // preprocess (first)
       const [leadingSpace, classNameWithoutSpacesAtBothEnds, trailingSpace] =
@@ -485,7 +495,7 @@ async function replaceClassNameAsync({
         .reduce((textLength, line) => textLength + line.length + EOL.length, 0);
       const firstLineIndentLength = indentUnit.length * baseIndentLevel;
       const firstLinePadLength =
-        rangeStart +
+        classNameNodeRangeStart +
         1 -
         totalTextLengthUptoPrevLine -
         firstLineIndentLength +
@@ -614,7 +624,7 @@ async function replaceClassNameAsync({
           : 0;
       const classNamePartialWrappedText = `${formattedPrevText.slice(
         0,
-        rangeStart - sliceOffset + (isAttributeType ? 1 : 0),
+        classNameNodeRangeStart - sliceOffset + (isAttributeType ? 1 : 0),
       )}${substitute}${
         isAttributeType
           ? formattedPrevText.slice(
@@ -636,9 +646,13 @@ async function replaceClassNameAsync({
         const [nthNodeRangeStart, nthNodeRangeEnd] =
           targetClassNameNodes[rangeCorrectionIndex].range;
 
-        if (nthNodeRangeStart < rangeStart && rangeEnd < nthNodeRangeEnd) {
+        if (
+          nthNodeRangeStart < classNameNodeRangeStart &&
+          classNameNodeRangeEnd < nthNodeRangeEnd
+        ) {
           // eslint-disable-next-line no-param-reassign
-          array[rangeCorrectionIndex] += correctedRangeEnd - rangeStart - substitute.length;
+          array[rangeCorrectionIndex] +=
+            correctedRangeEnd - classNameNodeRangeStart - substitute.length;
         }
       });
 

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -149,7 +149,7 @@ function replaceClassName({
   lineNodes,
   options,
   format,
-  targetClassNameTypes,
+  isSecondPhase,
 }: {
   formattedText: string;
   indentUnit: string;
@@ -157,7 +157,7 @@ function replaceClassName({
   lineNodes: LineNode[];
   options: NarrowedParserOptions;
   format: (source: string, options?: any) => string;
-  targetClassNameTypes?: ClassNameType[];
+  isSecondPhase: boolean;
 }): string {
   const freezer: { type: 'string' | 'indent'; from: string; to: string }[] = [];
   const rangeCorrectionValues = [...Array(targetClassNameNodes.length)].map(() => 0);
@@ -168,7 +168,14 @@ function replaceClassName({
       { type, range: [rangeStart, rangeEnd], startLineIndex, elementName },
       classNameNodeIndex,
     ) => {
-      if (targetClassNameTypes && !targetClassNameTypes.includes(type)) {
+      if (
+        isSecondPhase &&
+        !(
+          options.parser === 'vue' || options.parser === 'astro'
+            ? [ClassNameType.ASL, ClassNameType.AOL]
+            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL]
+        ).includes(type)
+      ) {
         return formattedPrevText;
       }
 
@@ -364,14 +371,14 @@ export function parseLineByLineAndReplace({
   options,
   format,
   addon,
-  targetClassNameTypes,
+  isSecondPhase,
 }: {
   formattedText: string;
   ast: any;
   options: NarrowedParserOptions;
   format: (source: string, options?: any) => string;
   addon: Dict<(text: string, options: any) => any>;
-  targetClassNameTypes?: ClassNameType[];
+  isSecondPhase: boolean;
 }): string {
   if (formattedText === '') {
     return formattedText;
@@ -404,12 +411,10 @@ export function parseLineByLineAndReplace({
     lineNodes,
     options,
     format,
-    targetClassNameTypes,
+    isSecondPhase,
   });
-  // Note: This is a temporary use condition. I plan to improve it in the next minor update.
-  const conditionForSecondFormat = targetClassNameTypes !== undefined;
 
-  return conditionForSecondFormat
+  return isSecondPhase
     ? classNameWrappedText.replace(new RegExp(`^\\s*${doubleFrozenAttributeName}${EOL}`, 'gm'), '')
     : classNameWrappedText;
 }
@@ -421,7 +426,7 @@ async function replaceClassNameAsync({
   lineNodes,
   options,
   format,
-  targetClassNameTypes,
+  isSecondPhase,
 }: {
   formattedText: string;
   indentUnit: string;
@@ -429,7 +434,7 @@ async function replaceClassNameAsync({
   lineNodes: LineNode[];
   options: NarrowedParserOptions;
   format: (source: string, options?: any) => Promise<string>;
-  targetClassNameTypes?: ClassNameType[];
+  isSecondPhase: boolean;
 }): Promise<string> {
   const freezer: { type: 'string' | 'indent'; from: string; to: string }[] = [];
   const rangeCorrectionValues = [...Array(targetClassNameNodes.length)].map(() => 0);
@@ -440,7 +445,14 @@ async function replaceClassNameAsync({
       { type, range: [rangeStart, rangeEnd], startLineIndex, elementName },
       classNameNodeIndex,
     ) => {
-      if (targetClassNameTypes && !targetClassNameTypes.includes(type)) {
+      if (
+        isSecondPhase &&
+        !(
+          options.parser === 'vue' || options.parser === 'astro'
+            ? [ClassNameType.ASL, ClassNameType.AOL]
+            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL]
+        ).includes(type)
+      ) {
         return formattedPrevTextPromise;
       }
 
@@ -642,14 +654,14 @@ export async function parseLineByLineAndReplaceAsync({
   options,
   format,
   addon,
-  targetClassNameTypes,
+  isSecondPhase,
 }: {
   formattedText: string;
   ast: any;
   options: NarrowedParserOptions;
   format: (source: string, options?: any) => Promise<string>;
   addon: Dict<(text: string, options: any) => any>;
-  targetClassNameTypes?: ClassNameType[];
+  isSecondPhase: boolean;
 }): Promise<string> {
   if (formattedText === '') {
     return formattedText;
@@ -682,12 +694,10 @@ export async function parseLineByLineAndReplaceAsync({
     lineNodes,
     options,
     format,
-    targetClassNameTypes,
+    isSecondPhase,
   });
-  // Note: This is a temporary use condition. I plan to improve it in the next minor update.
-  const conditionForSecondFormat = targetClassNameTypes !== undefined;
 
-  return conditionForSecondFormat
+  return isSecondPhase
     ? classNameWrappedText.replace(new RegExp(`^\\s*${doubleFrozenAttributeName}${EOL}`, 'gm'), '')
     : classNameWrappedText;
 }

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -25,18 +25,18 @@ function parseLineByLine(formattedText: string, indentUnit: string): LineNode[] 
   });
 }
 
-function getExtraIndentLevel(type: ClassNameType) {
-  if (type === ClassNameType.ASL) {
+function getExtraIndentLevel(node: ClassNameNode) {
+  if (node.type === ClassNameType.ASL) {
     return 2;
   }
 
   if (
-    type === ClassNameType.AOL ||
-    type === ClassNameType.SLSL ||
-    type === ClassNameType.SLTO ||
-    type === ClassNameType.TLSL ||
-    type === ClassNameType.TLTO ||
-    type === ClassNameType.TLPQTO
+    node.type === ClassNameType.AOL ||
+    node.type === ClassNameType.SLSL ||
+    node.type === ClassNameType.SLTO ||
+    node.type === ClassNameType.TLSL ||
+    node.type === ClassNameType.TLTO ||
+    node.type === ClassNameType.TLPQTO
   ) {
     return 1;
   }
@@ -45,37 +45,37 @@ function getExtraIndentLevel(type: ClassNameType) {
 }
 
 function getSomeKindOfQuotes(
-  type: ClassNameType,
+  node: ClassNameNode,
   isMultiLineClassName: boolean,
   parser: string,
 ): [string, string] {
   const baseQuote =
     // eslint-disable-next-line no-nested-ternary
-    type === ClassNameType.TLPQ || type === ClassNameType.TLPQTO
+    node.type === ClassNameType.TLPQ || node.type === ClassNameType.TLPQTO
       ? '`'
       : parser === 'vue' &&
-        (type === ClassNameType.FA ||
-          type === ClassNameType.CSL ||
-          type === ClassNameType.SLSL ||
-          type === ClassNameType.SLOP ||
-          type === ClassNameType.SLTO ||
-          type === ClassNameType.CTL ||
-          type === ClassNameType.TLSL ||
-          type === ClassNameType.TLOP ||
-          type === ClassNameType.TLTO)
+        (node.type === ClassNameType.FA ||
+          node.type === ClassNameType.CSL ||
+          node.type === ClassNameType.SLSL ||
+          node.type === ClassNameType.SLOP ||
+          node.type === ClassNameType.SLTO ||
+          node.type === ClassNameType.CTL ||
+          node.type === ClassNameType.TLSL ||
+          node.type === ClassNameType.TLOP ||
+          node.type === ClassNameType.TLTO)
       ? "'"
       : '"';
 
-  const opener = `${isMultiLineClassName && type === ClassNameType.SLOP ? '[' : ''}${
-    !isMultiLineClassName || type === ClassNameType.ASL || type === ClassNameType.AOL
+  const opener = `${isMultiLineClassName && node.type === ClassNameType.SLOP ? '[' : ''}${
+    !isMultiLineClassName || node.type === ClassNameType.ASL || node.type === ClassNameType.AOL
       ? baseQuote
       : '`'
   }`;
   const closer = `${
-    !isMultiLineClassName || type === ClassNameType.ASL || type === ClassNameType.AOL
+    !isMultiLineClassName || node.type === ClassNameType.ASL || node.type === ClassNameType.AOL
       ? baseQuote
       : '`'
-  }${isMultiLineClassName && type === ClassNameType.SLOP ? ']' : ''}`;
+  }${isMultiLineClassName && node.type === ClassNameType.SLOP ? ']' : ''}`;
 
   return [opener, closer];
 }
@@ -155,11 +155,14 @@ function replaceClassName({
   const rangeCorrectionValues = [...Array(targetClassNameNodes.length)].map(() => 0);
 
   const icedFormattedText = targetClassNameNodes.reduce(
-    (
-      formattedPrevText,
-      { type, range: [rangeStart, rangeEnd], startLineIndex, elementName },
-      classNameNodeIndex,
-    ) => {
+    (formattedPrevText, classNameNode, classNameNodeIndex) => {
+      const {
+        type,
+        range: [rangeStart, rangeEnd],
+        startLineIndex,
+        elementName,
+      } = classNameNode;
+
       if (
         isSecondPhase &&
         (((options.parser === 'vue' || options.parser === 'astro') &&
@@ -182,7 +185,7 @@ function replaceClassName({
       const isOutputIdeal = isStartingPositionRelative && isEndingPositionAbsolute;
 
       const { indentLevel: baseIndentLevel } = lineNodes[startLineIndex];
-      const extraIndentLevel = getExtraIndentLevel(type);
+      const extraIndentLevel = getExtraIndentLevel(classNameNode);
       const multiLineIndentLevel = isStartingPositionRelative
         ? baseIndentLevel + extraIndentLevel
         : 0;
@@ -259,7 +262,7 @@ function replaceClassName({
 
       const isMultiLineClassName = classNameWithOriginalSpaces.split(EOL).length > 1;
       const [quoteStart, quoteEnd] = getSomeKindOfQuotes(
-        type,
+        classNameNode,
         isMultiLineClassName,
         options.parser,
       );
@@ -436,11 +439,14 @@ async function replaceClassNameAsync({
   const rangeCorrectionValues = [...Array(targetClassNameNodes.length)].map(() => 0);
 
   const icedFormattedText = await targetClassNameNodes.reduce(
-    async (
-      formattedPrevTextPromise,
-      { type, range: [rangeStart, rangeEnd], startLineIndex, elementName },
-      classNameNodeIndex,
-    ) => {
+    async (formattedPrevTextPromise, classNameNode, classNameNodeIndex) => {
+      const {
+        type,
+        range: [rangeStart, rangeEnd],
+        startLineIndex,
+        elementName,
+      } = classNameNode;
+
       if (
         isSecondPhase &&
         (((options.parser === 'vue' || options.parser === 'astro') &&
@@ -465,7 +471,7 @@ async function replaceClassNameAsync({
       const isOutputIdeal = isStartingPositionRelative && isEndingPositionAbsolute;
 
       const { indentLevel: baseIndentLevel } = lineNodes[startLineIndex];
-      const extraIndentLevel = getExtraIndentLevel(type);
+      const extraIndentLevel = getExtraIndentLevel(classNameNode);
       const multiLineIndentLevel = isStartingPositionRelative
         ? baseIndentLevel + extraIndentLevel
         : 0;
@@ -546,7 +552,7 @@ async function replaceClassNameAsync({
 
       const isMultiLineClassName = classNameWithOriginalSpaces.split(EOL).length > 1;
       const [quoteStart, quoteEnd] = getSomeKindOfQuotes(
-        type,
+        classNameNode,
         isMultiLineClassName,
         options.parser,
       );

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -24,6 +24,16 @@ export const TAB = '\t';
 export const TAB_SIZE = 4;
 
 /**
+ * single quote character
+ */
+export const SINGLE_QUOTE = "'";
+
+/**
+ * double quote character
+ */
+export const DOUBLE_QUOTE = '"';
+
+/**
  * @deprecated
  */
 export enum ClassNameType {
@@ -108,10 +118,13 @@ type LegacyNode = ClassNameNodeBase & {
 
 type UnknownNode = ClassNameNodeBase & {
   type: 'unknown';
+  delimiterType: 'single-quote' | 'double-quote' | 'backtick';
 };
 
 type AttributeNode = ClassNameNodeBase & {
   type: 'attribute';
+  isTheFirstLineOnTheSameLineAsTheOpeningTag: boolean;
+  elementName: string;
 };
 
 type ExpressionNode = ClassNameNodeBase & {

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -33,72 +33,6 @@ export const SINGLE_QUOTE = "'";
  */
 export const DOUBLE_QUOTE = '"';
 
-/**
- * @deprecated
- */
-export enum ClassNameType {
-  /**
-   * Attributes on the same line as the opening tag and enclosed in quotes
-   */
-  ASL,
-  /**
-   * Attributes on their own line and enclosed in quotes
-   */
-  AOL,
-  /**
-   * String literal or template literal passed as function argument
-   */
-  FA,
-  /**
-   * Common string literal
-   */
-  CSL,
-  /**
-   * String literal starting on the same line as the attribute
-   */
-  SLSL,
-  /**
-   * String literal as object property
-   */
-  SLOP,
-  /**
-   * String literal in ternary operator
-   */
-  SLTO,
-  /**
-   * Common template literal
-   */
-  CTL,
-  /**
-   * Template literal starting on the same line as the attribute
-   */
-  TLSL,
-  /**
-   * Template literal as object property
-   */
-  TLOP,
-  /**
-   * Template literal in ternary operator
-   */
-  TLTO,
-  /**
-   * Template literal that preserve quotes
-   */
-  TLPQ,
-  /**
-   * Template literal that preserve quotes (in ternary operator)
-   */
-  TLPQTO,
-  /**
-   * Unknown string literal
-   */
-  USL,
-  /**
-   * Unknown template literal
-   */
-  UTL,
-}
-
 export type Dict<T = unknown> = Record<string, T | undefined>;
 
 export type NodeRange = [number, number];
@@ -106,14 +40,6 @@ export type NodeRange = [number, number];
 type ClassNameNodeBase = {
   range: NodeRange;
   startLineIndex: number;
-};
-
-/**
- * @deprecated
- */
-type LegacyNode = ClassNameNodeBase & {
-  type: ClassNameType;
-  elementName?: string;
 };
 
 type UnknownNode = ClassNameNodeBase & {
@@ -137,7 +63,7 @@ type ExpressionNode = ClassNameNodeBase & {
   shouldKeepDelimiter: boolean;
 };
 
-export type ClassNameNode = LegacyNode | UnknownNode | AttributeNode | ExpressionNode;
+export type ClassNameNode = UnknownNode | AttributeNode | ExpressionNode;
 
 export type NarrowedParserOptions = {
   printWidth: number;

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -53,7 +53,7 @@ type AttributeNode = ClassNameNodeBase & {
   elementName: string;
 };
 
-type ExpressionNode = ClassNameNodeBase & {
+export type ExpressionNode = ClassNameNodeBase & {
   type: 'expression';
   delimiterType: 'single-quote' | 'double-quote' | 'backtick';
   isTheFirstLineOnTheSameLineAsTheAttributeName: boolean;

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -23,6 +23,9 @@ export const TAB = '\t';
  */
 export const TAB_SIZE = 4;
 
+/**
+ * @deprecated
+ */
 export enum ClassNameType {
   /**
    * Attributes on the same line as the opening tag and enclosed in quotes
@@ -90,12 +93,32 @@ export type Dict<T = unknown> = Record<string, T | undefined>;
 
 export type NodeRange = [number, number];
 
-export type ClassNameNode = {
-  type: ClassNameType;
+type ClassNameNodeBase = {
   range: NodeRange;
   startLineIndex: number;
+};
+
+/**
+ * @deprecated
+ */
+type LegacyNode = ClassNameNodeBase & {
+  type: ClassNameType;
   elementName?: string;
 };
+
+type UnknownNode = ClassNameNodeBase & {
+  type: 'unknown';
+};
+
+type AttributeNode = ClassNameNodeBase & {
+  type: 'attribute';
+};
+
+type ExpressionNode = ClassNameNodeBase & {
+  type: 'expression';
+};
+
+export type ClassNameNode = LegacyNode | UnknownNode | AttributeNode | ExpressionNode;
 
 export type NarrowedParserOptions = {
   printWidth: number;

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -129,6 +129,12 @@ type AttributeNode = ClassNameNodeBase & {
 
 type ExpressionNode = ClassNameNodeBase & {
   type: 'expression';
+  delimiterType: 'single-quote' | 'double-quote' | 'backtick';
+  isTheFirstLineOnTheSameLineAsTheAttributeName: boolean;
+  isItAnObjectProperty: boolean;
+  isItAnOperandOfTernaryOperator: boolean;
+  isItFunctionArgument: boolean;
+  shouldKeepDelimiter: boolean;
 };
 
 export type ClassNameNode = LegacyNode | UnknownNode | AttributeNode | ExpressionNode;

--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -1,5 +1,4 @@
 import { parseLineByLineAndReplace } from 'core-parts';
-import { ClassNameType } from 'core-parts/shared';
 import type { Parser, ParserOptions, Plugin } from 'prettier';
 import { format } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
@@ -59,6 +58,7 @@ function transformParser(
         options,
         format,
         addon,
+        isSecondPhase: false,
       });
 
       let secondFormattedText: string;
@@ -87,10 +87,7 @@ function transformParser(
         options,
         format,
         addon,
-        targetClassNameTypes:
-          parserName === 'vue' || parserName === 'astro'
-            ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL],
+        isSecondPhase: true,
       });
 
       return {

--- a/src/packages/v3-plugin/parsers.ts
+++ b/src/packages/v3-plugin/parsers.ts
@@ -1,5 +1,4 @@
 import { parseLineByLineAndReplaceAsync } from 'core-parts';
-import { ClassNameType } from 'core-parts/shared';
 import type { Parser, ParserOptions, Plugin } from 'prettier';
 import { format } from 'prettier';
 import { parsers as babelParsers } from 'prettier/plugins/babel';
@@ -58,6 +57,7 @@ function transformParser(
         options,
         format,
         addon,
+        isSecondPhase: false,
       });
 
       let secondFormattedText: string;
@@ -82,10 +82,7 @@ function transformParser(
         options,
         format,
         addon,
-        targetClassNameTypes:
-          parserName === 'vue' || parserName === 'astro'
-            ? [ClassNameType.ASL, ClassNameType.AOL]
-            : [ClassNameType.ASL, ClassNameType.AOL, ClassNameType.CTL, ClassNameType.TLSL],
+        isSecondPhase: true,
       });
 
       return {


### PR DESCRIPTION
Previously, class name nodes were classified as one of the predefined enum members, so if a specific node had two properties at the same time, a new enum member had to be defined.

By individually defining the properties that a class name node can have, it is now possible to turn on/off only that property even if it has multiple properties.