### PR TITLE
Excludes tagged templates starting with `css` from line wrapping

### DIFF
--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -658,6 +658,31 @@ export function findTargetClassNameNodes(ast: any, options: ResolvedOptions): Cl
         nonCommentNodes.push(currentASTNode);
 
         if (
+          isTypeof(
+            node,
+            z.object({
+              tag: z.object({
+                type: z.literal('Identifier'),
+                name: z.string(),
+                range: z.custom<NodeRange>((value) =>
+                  isTypeof(value, z.tuple([z.number(), z.number()])),
+                ),
+              }),
+            }),
+          ) &&
+          node.tag.name === 'css'
+        ) {
+          const [tagRangeStart, tagRangeEnd] = node.tag.range;
+
+          // Note: In fact, the tag name is not `prettierIgnoreNode`, but it is considered a kind of ignore comment to ignore the template literal that immediately follows it.
+          prettierIgnoreNodes.push({
+            type: node.tag.type,
+            range: [tagRangeStart, tagRangeEnd - 1],
+          });
+          break;
+        }
+
+        if (
           (isTypeof(
             node,
             z.object({
@@ -2609,6 +2634,31 @@ export function findTargetClassNameNodesForSvelte(
       }
       case 'TaggedTemplateExpression': {
         nonCommentNodes.push(currentASTNode);
+
+        if (
+          isTypeof(
+            node,
+            z.object({
+              tag: z.object({
+                type: z.literal('Identifier'),
+                name: z.string(),
+                start: z.number(),
+                end: z.number(),
+              }),
+            }),
+          ) &&
+          node.tag.name === 'css'
+        ) {
+          const tagRangeStart = node.tag.start;
+          const tagRangeEnd = node.tag.end;
+
+          // Note: In fact, the tag name is not `prettierIgnoreNode`, but it is considered a kind of ignore comment to ignore the template literal that immediately follows it.
+          prettierIgnoreNodes.push({
+            type: node.tag.type,
+            range: [tagRangeStart, tagRangeEnd - 1],
+          });
+          break;
+        }
 
         if (
           (isTypeof(

--- a/tests/v2-test/adaptor.ts
+++ b/tests/v2-test/adaptor.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'prettier';
 import { format } from 'prettier';
 import type { Fixture } from 'test-settings';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, onTestFailed, test } from 'vitest';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as thisPlugin from '@/packages/v2-plugin';
@@ -24,6 +24,38 @@ export function testEach(
     });
 
     test.runIf(formattedText === output)('consistency', () => {
+      const doubleFormattedText = format(formattedText, fixedOptions);
+
+      expect(doubleFormattedText).toBe(formattedText);
+    });
+  });
+}
+
+export function testSnapshotEach(
+  fixtures: Omit<Fixture, 'output'>[],
+  options: PrettierBaseOptions & { plugins: (string | Plugin)[] },
+) {
+  describe.each(fixtures)('$name', ({ input, options: fixtureOptions }) => {
+    const fixedOptions = {
+      ...options,
+      ...(fixtureOptions ?? {}),
+    };
+    const formattedText = format(input, fixedOptions);
+    let skipSecondTest = false;
+
+    test('expectation', () => {
+      onTestFailed(() => {
+        skipSecondTest = true;
+      });
+
+      expect(formattedText).toMatchSnapshot();
+    });
+
+    test('consistency', ({ skip }) => {
+      if (skipSecondTest) {
+        skip();
+      }
+
       const doubleFormattedText = format(formattedText, fixedOptions);
 
       expect(doubleFormattedText).toBe(formattedText);

--- a/tests/v2-test/angular/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/angular/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/angular/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/angular/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+    elit proin ex massa hendrerit eu posuere eu volutpat id
+    neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/angular/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/angular/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+    ex massa hendrerit eu posuere eu volutpat id neque
+    pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/angular/issue-73/absolute.test.ts
+++ b/tests/v2-test/angular/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/angular/issue-73/fixtures.ts
+++ b/tests/v2-test/angular/issue-73/fixtures.ts
@@ -1,0 +1,55 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/angular/issue-73/ideal.test.ts
+++ b/tests/v2-test/angular/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/angular/issue-73/relative.test.ts
+++ b/tests/v2-test/angular/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-73/absolute.test.ts
+++ b/tests/v2-test/astro/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/issue-73/fixtures.ts
+++ b/tests/v2-test/astro/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/astro/issue-73/ideal.test.ts
+++ b/tests/v2-test/astro/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/issue-73/relative.test.ts
+++ b/tests/v2-test/astro/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-73/absolute.test.ts
+++ b/tests/v2-test/babel/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-73/fixtures.ts
+++ b/tests/v2-test/babel/issue-73/fixtures.ts
@@ -1,0 +1,63 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/babel/issue-73/ideal.test.ts
+++ b/tests/v2-test/babel/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-73/relative.test.ts
+++ b/tests/v2-test/babel/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/html/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/html/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/html/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/html/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+    elit proin ex massa hendrerit eu posuere eu volutpat id
+    neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/html/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/html/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+    ex massa hendrerit eu posuere eu volutpat id neque
+    pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v2-test/html/issue-73/absolute.test.ts
+++ b/tests/v2-test/html/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/html/issue-73/fixtures.ts
+++ b/tests/v2-test/html/issue-73/fixtures.ts
@@ -1,0 +1,55 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/html/issue-73/ideal.test.ts
+++ b/tests/v2-test/html/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/html/issue-73/relative.test.ts
+++ b/tests/v2-test/html/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-73/absolute.test.ts
+++ b/tests/v2-test/svelte/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/issue-73/fixtures.ts
+++ b/tests/v2-test/svelte/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/svelte/issue-73/ideal.test.ts
+++ b/tests/v2-test/svelte/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/issue-73/relative.test.ts
+++ b/tests/v2-test/svelte/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-73/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-73/fixtures.ts
+++ b/tests/v2-test/typescript/issue-73/fixtures.ts
@@ -1,0 +1,63 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/typescript/issue-73/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-73/relative.test.ts
+++ b/tests/v2-test/typescript/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere eu volutpat
+        id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-73/absolute.test.ts
+++ b/tests/v2-test/vue/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/issue-73/fixtures.ts
+++ b/tests/v2-test/vue/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v2-test/vue/issue-73/ideal.test.ts
+++ b/tests/v2-test/vue/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/issue-73/relative.test.ts
+++ b/tests/v2-test/vue/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/adaptor.ts
+++ b/tests/v3-test/adaptor.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from 'prettier';
 import { format } from 'prettier';
 import type { Fixture } from 'test-settings';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, onTestFailed, test } from 'vitest';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as thisPlugin from '@/packages/v3-plugin';
@@ -24,6 +24,38 @@ export function testEach(
     });
 
     test.runIf(formattedText === output)('consistency', async () => {
+      const doubleFormattedText = await format(formattedText, fixedOptions);
+
+      expect(doubleFormattedText).toBe(formattedText);
+    });
+  });
+}
+
+export function testSnapshotEach(
+  fixtures: Omit<Fixture, 'output'>[],
+  options: PrettierBaseOptions & { plugins: (string | Plugin)[] },
+) {
+  describe.each(fixtures)('$name', async ({ input, options: fixtureOptions }) => {
+    const fixedOptions = {
+      ...options,
+      ...(fixtureOptions ?? {}),
+    };
+    const formattedText = await format(input, fixedOptions);
+    let skipSecondTest = false;
+
+    test('expectation', () => {
+      onTestFailed(() => {
+        skipSecondTest = true;
+      });
+
+      expect(formattedText).toMatchSnapshot();
+    });
+
+    test('consistency', async ({ skip }) => {
+      if (skipSecondTest) {
+        skip();
+      }
+
       const doubleFormattedText = await format(formattedText, fixedOptions);
 
       expect(doubleFormattedText).toBe(formattedText);

--- a/tests/v3-test/angular/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/angular/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/angular/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/angular/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+    elit proin ex massa hendrerit eu posuere eu volutpat id
+    neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/angular/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/angular/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+    ex massa hendrerit eu posuere eu volutpat id neque
+    pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/angular/issue-73/absolute.test.ts
+++ b/tests/v3-test/angular/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/angular/issue-73/fixtures.ts
+++ b/tests/v3-test/angular/issue-73/fixtures.ts
@@ -1,0 +1,55 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/angular/issue-73/ideal.test.ts
+++ b/tests/v3-test/angular/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/angular/issue-73/relative.test.ts
+++ b/tests/v3-test/angular/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-73/absolute.test.ts
+++ b/tests/v3-test/astro/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/issue-73/fixtures.ts
+++ b/tests/v3-test/astro/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/astro/issue-73/ideal.test.ts
+++ b/tests/v3-test/astro/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/issue-73/relative.test.ts
+++ b/tests/v3-test/astro/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-73/absolute.test.ts
+++ b/tests/v3-test/babel/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-73/fixtures.ts
+++ b/tests/v3-test/babel/issue-73/fixtures.ts
@@ -1,0 +1,63 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/babel/issue-73/ideal.test.ts
+++ b/tests/v3-test/babel/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-73/relative.test.ts
+++ b/tests/v3-test/babel/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/html/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/html/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/html/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/html/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing
+    elit proin ex massa hendrerit eu posuere eu volutpat id
+    neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/html/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/html/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+    ex massa hendrerit eu posuere eu volutpat id neque
+    pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+  const classes = classNames(
+    css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`,
+  );
+</script>
+"
+`;

--- a/tests/v3-test/html/issue-73/absolute.test.ts
+++ b/tests/v3-test/html/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/html/issue-73/fixtures.ts
+++ b/tests/v3-test/html/issue-73/fixtures.ts
@@ -1,0 +1,55 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an argument for a function that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an argument for a function that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = classNames(css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`);
+</script>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/html/issue-73/ideal.test.ts
+++ b/tests/v3-test/html/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/html/issue-73/relative.test.ts
+++ b/tests/v3-test/html/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'html',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur
+  adipiscing elit proin ex massa hendrerit eu posuere eu
+  volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,63 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+  const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+  ex massa hendrerit eu posuere eu volutpat id neque
+  pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div
+      class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-73/absolute.test.ts
+++ b/tests/v3-test/svelte/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/issue-73/fixtures.ts
+++ b/tests/v3-test/svelte/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script>
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<div>
+  <div>
+    <div class={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/svelte/issue-73/ideal.test.ts
+++ b/tests/v3-test/svelte/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/issue-73/relative.test.ts
+++ b/tests/v3-test/svelte/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,59 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div
+      className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-73/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-73/fixtures.ts
+++ b/tests/v3-test/typescript/issue-73/fixtures.ts
@@ -1,0 +1,63 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+//---------------------------------------------------------| printWidth=60
+export function Foo({ children }) {
+  return (
+    <div className={css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/typescript/issue-73/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-73/relative.test.ts
+++ b/tests/v3-test/typescript/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/issue-73/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/issue-73/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere eu volutpat id
+neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-73/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/issue-73/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere eu volutpat
+        id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-73/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/issue-73/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Tagged templates are not supported by default.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(2) Tagged templates are supported by adding tag function names to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+ex massa hendrerit eu posuere eu volutpat id neque
+pellentesque\`;
+</script>
+"
+`;
+
+exports[`'(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the \`customFunctions\` option does not include the tagged function name, but in fact it is supported as a template literal.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(4) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(5) If the tag function name is \`css\`, the tagged template is considered special and is not supported even if you add the tag function name to the \`customFunctions\` option.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div
+      :class="
+        css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-73/absolute.test.ts
+++ b/tests/v3-test/vue/issue-73/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/issue-73/fixtures.ts
+++ b/tests/v3-test/vue/issue-73/fixtures.ts
@@ -1,0 +1,67 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Tagged templates are not supported by default.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+  },
+  {
+    name: '(2) Tagged templates are supported by adding tag function names to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<script setup lang="ts">
+const classes = tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`;
+</script>
+`,
+    options: {
+      customFunctions: ['tw'],
+    },
+  },
+  {
+    name: '(3) If a tagged template is written as an expression for an attribute that supports line wrapping, it will appear to be supported even if the `customFunctions` option does not include the tagged function name, but in fact it is supported as a template literal.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="tw\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+  },
+  {
+    name: '(4) If the tag function name is `css`, the tagged template is considered special and is not supported even if it is written as an expression for an attribute that supports line wrapping.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+  },
+  {
+    name: '(5) If the tag function name is `css`, the tagged template is considered special and is not supported even if you add the tag function name to the `customFunctions` option.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 -->
+<template>
+  <div>
+    <div :class="css\`lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      customFunctions: ['css'],
+    },
+  },
+];

--- a/tests/v3-test/vue/issue-73/ideal.test.ts
+++ b/tests/v3-test/vue/issue-73/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/issue-73/relative.test.ts
+++ b/tests/v3-test/vue/issue-73/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR closes #73.