### PR TITLE
The closing delimiter is included in the line wrapping

### DIFF
--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -347,7 +347,12 @@ function formatTokens(
             .join('')
             .replace(/\t/g, SPACE.repeat(options.tabWidth))
         : '';
-      const classNameBase = `${PH.repeat(leadingText.length)}${token.body.trim()}`;
+      const trailingDelimiter = isEndingPositionAbsolute
+        ? formattedTokens[tokenIndex + 1].body
+        : '';
+      const classNameBase = `${PH.repeat(leadingText.length)}${token.body.trim()}${PH.repeat(
+        trailingDelimiter.length,
+      )}`;
 
       let formattedClassName = formatClassName(classNameBase, options.printWidth).slice(
         leadingText.length,
@@ -368,6 +373,7 @@ function formatTokens(
             : formattedLines.slice(1)),
         ].join(`${EOL}${indentUnit.repeat(multiLineIndentLevel)}`);
       }
+      formattedClassName = formattedClassName.slice(0, -trailingDelimiter.length || undefined);
 
       token.body = formattedClassName;
     } else if (token.type === 'expression') {
@@ -381,15 +387,20 @@ function formatTokens(
             .join('')
             .replace(/\t/g, SPACE.repeat(options.tabWidth))
         : '';
+      const trailingDelimiter = isEndingPositionAbsolute
+        ? formattedTokens[tokenIndex + 1].body
+        : '';
       const hasLeadingSpace = token.body !== token.body.trimStart();
       const hasTrailingSpace = token.body !== token.body.trimEnd();
       const classNameBase = `${PH.repeat(leadingText.length)}${
         hasLeadingSpace ? SPACE : ''
-      }${token.body.trim().replace(/\\\n/g, '')}`;
+      }${token.body.trim().replace(/\\\n/g, '')}${hasTrailingSpace ? SPACE : ''}${PH.repeat(
+        trailingDelimiter.length,
+      )}`;
 
       let formattedClassName = `${formatClassName(classNameBase, options.printWidth).slice(
         leadingText.length,
-      )}${hasTrailingSpace ? SPACE : ''}`;
+      )}${!trailingDelimiter && hasTrailingSpace ? SPACE : ''}`;
       const formattedLines = formattedClassName.split(EOL);
       const isMultiLineClassName = formattedLines.length > 1;
 
@@ -408,9 +419,10 @@ function formatTokens(
             ? `${formatClassName(
                 formattedLines.slice(1).join(EOL),
                 options.printWidth - options.tabWidth * multiLineIndentLevel,
-              )}${hasTrailingSpace ? SPACE : ''}`.split(EOL)
+              )}${!trailingDelimiter && hasTrailingSpace ? SPACE : ''}`.split(EOL)
             : formattedLines.slice(1)),
         ].join(`${EOL}${indentUnit.repeat(multiLineIndentLevel)}`);
+        formattedClassName = formattedClassName.slice(0, -trailingDelimiter.length || undefined);
 
         if (props.isItAngularExpression) {
           formattedTokens[tokenIndex - 1].body = SINGLE_QUOTE;
@@ -426,6 +438,8 @@ function formatTokens(
           }
         }
       } else {
+        formattedClassName = formattedClassName.slice(0, -trailingDelimiter.length || undefined);
+
         let baseDelimiter = DOUBLE_QUOTE;
 
         if (props.shouldKeepDelimiter) {

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -228,6 +228,9 @@ function replaceClassName({
         classNameNodeRangeStart + 1,
         correctedRangeEnd - 1,
       );
+      let trailingDelimiter = isEndingPositionAbsolute
+        ? formattedPrevText[correctedRangeEnd - 1]
+        : '';
       if (classNameNode.type === 'attribute') {
         classNameBase = classNameBase.trim();
       } else if (classNameNode.type === 'expression') {
@@ -258,7 +261,7 @@ function replaceClassName({
       // preprocess (first+1)
       const classNameWithFirstLinePadding = `${PH.repeat(
         isEndingPositionAbsolute ? firstLinePadLength : 0,
-      )}${classNameWithoutSpacesAtBothEnds}`;
+      )}${classNameWithoutSpacesAtBothEnds}${PH.repeat(trailingDelimiter.length)}`;
 
       const formattedClassName = ((cn: string) => {
         const formatted = format(cn, {
@@ -298,6 +301,7 @@ function replaceClassName({
       // postprocess (last-1)
       const classNameWithoutPadding = formattedClassName.slice(
         isEndingPositionAbsolute ? firstLinePadLength : 0,
+        -trailingDelimiter.length || undefined,
       );
 
       // postprocess (last)
@@ -560,6 +564,9 @@ async function replaceClassNameAsync({
         classNameNodeRangeStart + 1,
         correctedRangeEnd - 1,
       );
+      let trailingDelimiter = isEndingPositionAbsolute
+        ? formattedPrevText[correctedRangeEnd - 1]
+        : '';
       if (classNameNode.type === 'attribute') {
         classNameBase = classNameBase.trim();
       } else if (classNameNode.type === 'expression') {
@@ -590,7 +597,7 @@ async function replaceClassNameAsync({
       // preprocess (first+1)
       const classNameWithFirstLinePadding = `${PH.repeat(
         isEndingPositionAbsolute ? firstLinePadLength : 0,
-      )}${classNameWithoutSpacesAtBothEnds}`;
+      )}${classNameWithoutSpacesAtBothEnds}${PH.repeat(trailingDelimiter.length)}`;
 
       const formattedClassName = await (async (cn: string) => {
         const formatted = (
@@ -634,6 +641,7 @@ async function replaceClassNameAsync({
       // postprocess (last-1)
       const classNameWithoutPadding = formattedClassName.slice(
         isEndingPositionAbsolute ? firstLinePadLength : 0,
+        -trailingDelimiter.length || undefined,
       );
 
       // postprocess (last)

--- a/tests/v2-test/astro/complex-template/ideal.test.ts
+++ b/tests/v2-test/astro/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>
@@ -110,7 +111,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>

--- a/tests/v2-test/babel/complex-template/ideal.test.ts
+++ b/tests/v2-test/babel/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>
@@ -110,7 +111,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>

--- a/tests/v2-test/babel/issue-41/absolute.test.ts
+++ b/tests/v2-test/babel/issue-41/absolute.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
+    >
       content
     </section>
   );

--- a/tests/v2-test/babel/issue-41/ideal.test.ts
+++ b/tests/v2-test/babel/issue-41/ideal.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-      aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
+    >
       content
     </section>
   );

--- a/tests/v2-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
@@ -28,3 +28,18 @@ adipiscing\`}
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
@@ -28,3 +28,18 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+        adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/relative.test.ts.snap
@@ -27,3 +27,19 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        " lorem ipsum dolor sit amet consectetur adipiscing "
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/issue-72/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        "lorem ipsum dolor sit amet consectetur adipiscing"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-72/absolute.test.ts
+++ b/tests/v2-test/babel/issue-72/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-72/fixtures.ts
+++ b/tests/v2-test/babel/issue-72/fixtures.ts
@@ -15,7 +15,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 69,
-      experimentalOptimization: true,
     },
   },
   {
@@ -32,7 +31,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 58,
-      experimentalOptimization: true,
     },
   },
   {
@@ -49,7 +47,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 60,
-      experimentalOptimization: true,
     },
   },
 ];

--- a/tests/v2-test/babel/issue-72/fixtures.ts
+++ b/tests/v2-test/babel/issue-72/fixtures.ts
@@ -35,4 +35,21 @@ export function Foo({ children }) {
       experimentalOptimization: true,
     },
   },
+  {
+    name: '(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={' lorem ipsum dolor sit amet consectetur adipiscing '}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      experimentalOptimization: true,
+    },
+  },
 ];

--- a/tests/v2-test/babel/issue-72/fixtures.ts
+++ b/tests/v2-test/babel/issue-72/fixtures.ts
@@ -1,0 +1,38 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 69,
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={'lorem ipsum dolor sit amet consectetur adipiscing'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 58,
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/babel/issue-72/ideal.test.ts
+++ b/tests/v2-test/babel/issue-72/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-72/relative.test.ts
+++ b/tests/v2-test/babel/issue-72/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/complex-template/ideal.test.ts
+++ b/tests/v2-test/svelte/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>
@@ -110,7 +111,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>

--- a/tests/v2-test/typescript/complex-template/ideal.test.ts
+++ b/tests/v2-test/typescript/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>
@@ -110,7 +111,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>

--- a/tests/v2-test/typescript/issue-41/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-41/absolute.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
+    >
       content
     </section>
   );

--- a/tests/v2-test/typescript/issue-41/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-41/ideal.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-      aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
+    >
       content
     </section>
   );

--- a/tests/v2-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
@@ -28,3 +28,18 @@ adipiscing\`}
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
@@ -28,3 +28,18 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+        adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
@@ -27,3 +27,19 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        " lorem ipsum dolor sit amet consectetur adipiscing "
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        "lorem ipsum dolor sit amet consectetur adipiscing"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-72/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-72/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-72/fixtures.ts
+++ b/tests/v2-test/typescript/issue-72/fixtures.ts
@@ -15,7 +15,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 69,
-      experimentalOptimization: true,
     },
   },
   {
@@ -32,7 +31,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 58,
-      experimentalOptimization: true,
     },
   },
   {
@@ -49,7 +47,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 60,
-      experimentalOptimization: true,
     },
   },
 ];

--- a/tests/v2-test/typescript/issue-72/fixtures.ts
+++ b/tests/v2-test/typescript/issue-72/fixtures.ts
@@ -35,4 +35,21 @@ export function Foo({ children }) {
       experimentalOptimization: true,
     },
   },
+  {
+    name: '(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={' lorem ipsum dolor sit amet consectetur adipiscing '}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      experimentalOptimization: true,
+    },
+  },
 ];

--- a/tests/v2-test/typescript/issue-72/fixtures.ts
+++ b/tests/v2-test/typescript/issue-72/fixtures.ts
@@ -1,0 +1,38 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 69,
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={'lorem ipsum dolor sit amet consectetur adipiscing'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 58,
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/typescript/issue-72/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-72/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-72/relative.test.ts
+++ b/tests/v2-test/typescript/issue-72/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/complex-template/ideal.test.ts
+++ b/tests/v3-test/astro/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>
@@ -110,7 +111,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>

--- a/tests/v3-test/babel/complex-template/ideal.test.ts
+++ b/tests/v3-test/babel/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>
@@ -110,7 +111,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>

--- a/tests/v3-test/babel/issue-41/absolute.test.ts
+++ b/tests/v3-test/babel/issue-41/absolute.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
+    >
       content
     </section>
   );

--- a/tests/v3-test/babel/issue-41/ideal.test.ts
+++ b/tests/v3-test/babel/issue-41/ideal.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-      aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
+    >
       content
     </section>
   );

--- a/tests/v3-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
@@ -28,3 +28,18 @@ adipiscing\`}
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
@@ -28,3 +28,18 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+        adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/relative.test.ts.snap
@@ -27,3 +27,19 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        " lorem ipsum dolor sit amet consectetur adipiscing "
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/issue-72/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        "lorem ipsum dolor sit amet consectetur adipiscing"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-72/absolute.test.ts
+++ b/tests/v3-test/babel/issue-72/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-72/fixtures.ts
+++ b/tests/v3-test/babel/issue-72/fixtures.ts
@@ -15,7 +15,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 69,
-      experimentalOptimization: true,
     },
   },
   {
@@ -32,7 +31,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 58,
-      experimentalOptimization: true,
     },
   },
   {
@@ -49,7 +47,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 60,
-      experimentalOptimization: true,
     },
   },
 ];

--- a/tests/v3-test/babel/issue-72/fixtures.ts
+++ b/tests/v3-test/babel/issue-72/fixtures.ts
@@ -35,4 +35,21 @@ export function Foo({ children }) {
       experimentalOptimization: true,
     },
   },
+  {
+    name: '(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={' lorem ipsum dolor sit amet consectetur adipiscing '}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      experimentalOptimization: true,
+    },
+  },
 ];

--- a/tests/v3-test/babel/issue-72/fixtures.ts
+++ b/tests/v3-test/babel/issue-72/fixtures.ts
@@ -1,0 +1,38 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 69,
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={'lorem ipsum dolor sit amet consectetur adipiscing'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 58,
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/babel/issue-72/ideal.test.ts
+++ b/tests/v3-test/babel/issue-72/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-72/relative.test.ts
+++ b/tests/v3-test/babel/issue-72/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/complex-template/ideal.test.ts
+++ b/tests/v3-test/svelte/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>
@@ -110,7 +111,8 @@ const fixtures: Fixture[] = [
       class={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       <slot />
     </div>

--- a/tests/v3-test/typescript/complex-template/ideal.test.ts
+++ b/tests/v3-test/typescript/complex-template/ideal.test.ts
@@ -83,7 +83,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>
@@ -110,7 +111,8 @@ export function Foo({ children }) {
       className={\`lorem ipsum dolor sit amet \${\`lorem ipsum
         dolor sit amet
         \${"consectetur adipiscing elit proin"} ex massa
-        hendrerit eu posuere\`} ex massa hendrerit eu posuere\`}
+        hendrerit eu posuere\`} ex massa hendrerit eu
+        posuere\`}
     >
       {children}
     </div>

--- a/tests/v3-test/typescript/issue-41/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-41/absolute.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+p"
+    >
       content
     </section>
   );

--- a/tests/v3-test/typescript/issue-41/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-41/ideal.test.ts
@@ -25,7 +25,8 @@ export default function MyComponent() {
     output: `export default function MyComponent() {
   return (
     <section
-      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean p"
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
     >
       content
     </section>
@@ -49,8 +50,10 @@ export default function MyComponent() {
 `,
     output: `export default function MyComponent() {
   return (
-    <section className="lorem ipsum dolor sit amet consectetur adipiscing elit
-      aenean p">
+    <section
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit aenean
+        p"
+    >
       content
     </section>
   );

--- a/tests/v3-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
@@ -28,3 +28,18 @@ adipiscing\`}
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
@@ -28,3 +28,18 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\` lorem ipsum dolor sit amet consectetur
+        adipiscing \`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,30 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing"
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
@@ -27,3 +27,19 @@ export function Foo({ children }) {
 }
 "
 `;
+
+exports[`'(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        " lorem ipsum dolor sit amet consectetur adipiscing "
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/issue-72/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.' > expectation 1`] = `
+"//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        "lorem ipsum dolor sit amet consectetur adipiscing"
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-72/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-72/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-72/fixtures.ts
+++ b/tests/v3-test/typescript/issue-72/fixtures.ts
@@ -15,7 +15,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 69,
-      experimentalOptimization: true,
     },
   },
   {
@@ -32,7 +31,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 58,
-      experimentalOptimization: true,
     },
   },
   {
@@ -49,7 +47,6 @@ export function Foo({ children }) {
 `,
     options: {
       printWidth: 60,
-      experimentalOptimization: true,
     },
   },
 ];

--- a/tests/v3-test/typescript/issue-72/fixtures.ts
+++ b/tests/v3-test/typescript/issue-72/fixtures.ts
@@ -35,4 +35,21 @@ export function Foo({ children }) {
       experimentalOptimization: true,
     },
   },
+  {
+    name: '(3) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={' lorem ipsum dolor sit amet consectetur adipiscing '}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+      experimentalOptimization: true,
+    },
+  },
 ];

--- a/tests/v3-test/typescript/issue-72/fixtures.ts
+++ b/tests/v3-test/typescript/issue-72/fixtures.ts
@@ -1,0 +1,38 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//------------------------------------------------------------------| printWidth=69 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 69,
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(2) If the end position is absolute, the delimiter following the class name is also included in the line wrapping.',
+    input: `
+//-------------------------------------------------------| printWidth=58 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={'lorem ipsum dolor sit amet consectetur adipiscing'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 58,
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/typescript/issue-72/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-72/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-72/relative.test.ts
+++ b/tests/v3-test/typescript/issue-72/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR closes #72.

This feature works when the `endingPosition` option is `absolute` or `absolute-with-indent`.

In the following output, previously only the class name had to be within `printWidth`.

```
---------------------------------------------------------------------| printWidth=69
export function Foo({ children }) {
  return (
    <div className="lorem ipsum dolor sit amet consectetur adipiscing">
      {children}
    </div>
  );
}
```

Now the closing delimiter is also treated like a class name and falls within the `printWidth` range.

```
---------------------------------------------------------------------| printWidth=69
export function Foo({ children }) {
  return (
    <div
      className="lorem ipsum dolor sit amet consectetur adipiscing"
    >
      {children}
    </div>
  );
}
```