### PR TITLE
Print the message of the caught error in the second format

### DIFF
--- a/src/packages/v2-plugin/parsers.ts
+++ b/src/packages/v2-plugin/parsers.ts
@@ -7,12 +7,21 @@ import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
 const EOL = '\n';
 
+const SPACE = ' ';
+
 const addon = {
   parseBabel: (text: string, options: ParserOptions) =>
     babelParsers.babel.parse(text, { babel: babelParsers.babel }, options),
   parseTypescript: (text: string, options: ParserOptions) =>
     typescriptParsers.typescript.parse(text, { typescript: typescriptParsers.typescript }, options),
 };
+
+function addIndent(text: string, width = 2) {
+  return text
+    .split(EOL)
+    .map((line) => `${SPACE.repeat(width)}${line}`)
+    .join(EOL);
+}
 
 function transformParser(
   parserName: SupportedParserNames,
@@ -111,7 +120,9 @@ function transformParser(
         });
       } catch (error) {
         throw new Error(
-          'The second format failed. This is likely a bug in this plugin. Please file an issue.',
+          `The second format failed. This is likely a bug in this plugin. Please file an issue.${
+            error instanceof Error ? `${EOL}${addIndent(`Error: ${error.message}`, 4)}` : ''
+          }`,
         );
       }
 

--- a/src/packages/v3-plugin/parsers.ts
+++ b/src/packages/v3-plugin/parsers.ts
@@ -7,11 +7,20 @@ import { parsers as typescriptParsers } from 'prettier/plugins/typescript';
 
 const EOL = '\n';
 
+const SPACE = ' ';
+
 const addon = {
   parseBabel: (text: string, options: ParserOptions) => babelParsers.babel.parse(text, options),
   parseTypescript: (text: string, options: ParserOptions) =>
     typescriptParsers.typescript.parse(text, options),
 };
+
+function addIndent(text: string, width = 2) {
+  return text
+    .split(EOL)
+    .map((line) => `${SPACE.repeat(width)}${line}`)
+    .join(EOL);
+}
 
 function transformParser(
   parserName: SupportedParserNames,
@@ -115,7 +124,9 @@ function transformParser(
         });
       } catch (error) {
         throw new Error(
-          'The second format failed. This is likely a bug in this plugin. Please file an issue.',
+          `The second format failed. This is likely a bug in this plugin. Please file an issue.${
+            error instanceof Error ? `${EOL}${addIndent(`Error: ${error.message}`, 4)}` : ''
+          }`,
         );
       }
 


### PR DESCRIPTION
This PR prints the errors that occur during the second formatting process from an intermediate code perspective.

For example, in the process of testing #83, there are the following changes:

before:
```
Error: The second format failed. This is likely a bug in this plugin. Please file an issue.
 ❯ Object.parse ../../src/packages/v2-plugin/parsers.ts:122:15
...
```

after:
```
Error: The second format failed. This is likely a bug in this plugin. Please file an issue.
    Error: Unexpected token (10:11)
       8 |           "nodrag cursor-text h-full overflow-hidden":
       9 |             isEditing,
    > 10 |           `line-clamp-${lineClamp}`: !isEditing,
         |           ^
      11 |         },
      12 |       )}
      13 |     >
 ❯ Object.parse ../../src/packages/v2-plugin/parsers.ts:122:15
...
```