### PR TITLE
Ensures that line wrapping only occur on the last operand in logical expressions

### DIFF
--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -756,6 +756,40 @@ export function findTargetClassNameNodes(ast: any, options: ResolvedOptions): Cl
         }
         break;
       }
+      case 'LogicalExpression': {
+        nonCommentNodes.push(currentASTNode);
+
+        if (!options.experimentalOptimization) {
+          if (
+            isTypeof(
+              node,
+              z.object({
+                left: z.object({
+                  range: z.custom<NodeRange>((value) =>
+                    isTypeof(value, z.tuple([z.number(), z.number()])),
+                  ),
+                }),
+              }),
+            )
+          ) {
+            const [leftOperandRangeStart, leftOperandRangeEnd] = node.left.range;
+
+            classNameNodes.forEach((classNameNode) => {
+              const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
+
+              if (
+                leftOperandRangeStart <= classNameNodeRangeStart &&
+                classNameNodeRangeEnd <= leftOperandRangeEnd
+              ) {
+                // Note: Specifies a range that will not be included in `keywordStartingNode`, so that it will be filtered out in the final stage of the traversal.
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.range = [0, Infinity];
+              }
+            });
+          }
+        }
+        break;
+      }
       case 'Block':
       case 'Line': {
         if (
@@ -2779,6 +2813,40 @@ export function findTargetClassNameNodesForSvelte(
               }
             }
           });
+        }
+        break;
+      }
+      case 'LogicalExpression': {
+        nonCommentNodes.push(currentASTNode);
+
+        if (!options.experimentalOptimization) {
+          if (
+            isTypeof(
+              node,
+              z.object({
+                left: z.object({
+                  start: z.number(),
+                  end: z.number(),
+                }),
+              }),
+            )
+          ) {
+            const leftOperandRangeStart = node.left.start;
+            const leftOperandRangeEnd = node.left.end;
+
+            classNameNodes.forEach((classNameNode) => {
+              const [classNameNodeRangeStart, classNameNodeRangeEnd] = classNameNode.range;
+
+              if (
+                leftOperandRangeStart <= classNameNodeRangeStart &&
+                classNameNodeRangeEnd <= leftOperandRangeEnd
+              ) {
+                // Note: Specifies a range that will not be included in `keywordStartingNode`, so that it will be filtered out in the final stage of the traversal.
+                // eslint-disable-next-line no-param-reassign
+                classNameNode.range = [0, Infinity];
+              }
+            });
+          }
         }
         break;
       }

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -177,6 +177,10 @@ export function findTargetClassNameNodes(ast: any, options: ResolvedOptions): Cl
           recursiveProps = ['attributes'];
           break;
         }
+        case 'LogicalExpression': {
+          recursiveProps = ['right'];
+          break;
+        }
         case 'ObjectExpression': {
           recursiveProps = ['properties'];
           break;
@@ -2243,6 +2247,10 @@ export function findTargetClassNameNodesForSvelte(
         }
         case 'Literal': {
           recursiveProps = ['leadingComments'];
+          break;
+        }
+        case 'LogicalExpression': {
+          recursiveProps = ['right'];
           break;
         }
         case 'MustacheTag': {

--- a/tests/v2-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -17,7 +17,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -58,7 +58,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -75,7 +75,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -94,7 +94,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -116,7 +116,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -133,7 +133,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -151,7 +151,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,174 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/binary-operator/absolute.test.ts
+++ b/tests/v2-test/astro/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/binary-operator/fixtures.ts
+++ b/tests/v2-test/astro/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v2-test/astro/binary-operator/fixtures.ts
+++ b/tests/v2-test/astro/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/astro/binary-operator/ideal.test.ts
+++ b/tests/v2-test/astro/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/binary-operator/relative.test.ts
+++ b/tests/v2-test/astro/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -18,7 +18,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -61,7 +61,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -79,7 +79,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -99,7 +99,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -122,7 +122,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -140,7 +140,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -159,7 +159,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/binary-operator/absolute.test.ts
+++ b/tests/v2-test/babel/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/binary-operator/fixtures.ts
+++ b/tests/v2-test/babel/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -34,7 +34,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -50,7 +50,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -66,7 +66,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -82,7 +82,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -98,7 +98,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -114,7 +114,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -130,7 +130,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {

--- a/tests/v2-test/babel/binary-operator/fixtures.ts
+++ b/tests/v2-test/babel/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v2-test/babel/binary-operator/ideal.test.ts
+++ b/tests/v2-test/babel/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/binary-operator/relative.test.ts
+++ b/tests/v2-test/babel/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -17,7 +17,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -58,7 +58,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -75,7 +75,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -94,7 +94,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -116,7 +116,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -133,7 +133,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -151,7 +151,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,174 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/binary-operator/absolute.test.ts
+++ b/tests/v2-test/svelte/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/binary-operator/fixtures.ts
+++ b/tests/v2-test/svelte/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v2-test/svelte/binary-operator/fixtures.ts
+++ b/tests/v2-test/svelte/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>

--- a/tests/v2-test/svelte/binary-operator/ideal.test.ts
+++ b/tests/v2-test/svelte/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/binary-operator/relative.test.ts
+++ b/tests/v2-test/svelte/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -18,7 +18,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -61,7 +61,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -79,7 +79,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -99,7 +99,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -122,7 +122,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -140,7 +140,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -159,7 +159,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v2-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/binary-operator/absolute.test.ts
+++ b/tests/v2-test/typescript/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/binary-operator/fixtures.ts
+++ b/tests/v2-test/typescript/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -34,7 +34,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -50,7 +50,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -66,7 +66,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -82,7 +82,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -98,7 +98,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -114,7 +114,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -130,7 +130,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {

--- a/tests/v2-test/typescript/binary-operator/fixtures.ts
+++ b/tests/v2-test/typescript/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v2-test/typescript/binary-operator/ideal.test.ts
+++ b/tests/v2-test/typescript/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/binary-operator/relative.test.ts
+++ b/tests/v2-test/typescript/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,186 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -19,7 +19,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -62,7 +62,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -81,7 +81,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -102,7 +102,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -124,7 +124,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -143,7 +143,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -163,7 +163,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v2-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -19,7 +19,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -64,7 +64,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -83,7 +83,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -104,7 +104,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -128,7 +128,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -167,7 +167,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v2-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,192 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,186 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
@@ -19,7 +19,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -62,7 +62,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -81,7 +81,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -102,7 +102,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -124,7 +124,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -143,7 +143,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -163,7 +163,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v2-test/vue/binary-operator/absolute.test.ts
+++ b/tests/v2-test/vue/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/binary-operator/fixtures.ts
+++ b/tests/v2-test/vue/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>

--- a/tests/v2-test/vue/binary-operator/fixtures.ts
+++ b/tests/v2-test/vue/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v2-test/vue/binary-operator/ideal.test.ts
+++ b/tests/v2-test/vue/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/binary-operator/relative.test.ts
+++ b/tests/v2-test/vue/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -17,7 +17,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -58,7 +58,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -75,7 +75,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -94,7 +94,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -116,7 +116,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -133,7 +133,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -151,7 +151,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,174 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/binary-operator/absolute.test.ts
+++ b/tests/v3-test/astro/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/binary-operator/fixtures.ts
+++ b/tests/v3-test/astro/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v3-test/astro/binary-operator/fixtures.ts
+++ b/tests/v3-test/astro/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/astro/binary-operator/ideal.test.ts
+++ b/tests/v3-test/astro/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/binary-operator/relative.test.ts
+++ b/tests/v3-test/astro/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -18,7 +18,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -61,7 +61,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -79,7 +79,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -99,7 +99,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -122,7 +122,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -140,7 +140,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -159,7 +159,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/binary-operator/absolute.test.ts
+++ b/tests/v3-test/babel/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/binary-operator/fixtures.ts
+++ b/tests/v3-test/babel/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -34,7 +34,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -50,7 +50,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -66,7 +66,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -82,7 +82,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -98,7 +98,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -114,7 +114,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -130,7 +130,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {

--- a/tests/v3-test/babel/binary-operator/fixtures.ts
+++ b/tests/v3-test/babel/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v3-test/babel/binary-operator/ideal.test.ts
+++ b/tests/v3-test/babel/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/binary-operator/relative.test.ts
+++ b/tests/v3-test/babel/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -17,7 +17,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ elit proin ex massa hendrerit eu posuere\`}
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -58,7 +58,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -75,7 +75,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -94,7 +94,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -116,7 +116,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -133,7 +133,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -151,7 +151,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,174 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
@@ -17,7 +17,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -36,7 +36,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -56,7 +56,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -73,7 +73,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -92,7 +92,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -112,7 +112,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -129,7 +129,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,168 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div
+      class={null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/binary-operator/absolute.test.ts
+++ b/tests/v3-test/svelte/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/binary-operator/fixtures.ts
+++ b/tests/v3-test/svelte/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<div>
+  <div>
+    <div class={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v3-test/svelte/binary-operator/fixtures.ts
+++ b/tests/v3-test/svelte/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <div>

--- a/tests/v3-test/svelte/binary-operator/ideal.test.ts
+++ b/tests/v3-test/svelte/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/binary-operator/relative.test.ts
+++ b/tests/v3-test/svelte/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -18,7 +18,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -61,7 +61,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -79,7 +79,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -99,7 +99,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -122,7 +122,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -140,7 +140,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -159,7 +159,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
@@ -18,7 +18,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -38,7 +38,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -59,7 +59,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -77,7 +77,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -97,7 +97,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -118,7 +118,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -136,7 +136,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (
@@ -155,7 +155,7 @@ export function Foo({ children }) {
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
   return (

--- a/tests/v3-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,177 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        "lorem ipsum dolor sit amet" !==
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        "lorem ipsum dolor sit amet" ===
+          "consectetur adipiscing elit proin ex massa hendrerit eu posuere" ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        void "lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere" ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      }
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/binary-operator/absolute.test.ts
+++ b/tests/v3-test/typescript/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/binary-operator/fixtures.ts
+++ b/tests/v3-test/typescript/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -34,7 +34,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -50,7 +50,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -66,7 +66,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -82,7 +82,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -98,7 +98,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -114,7 +114,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {
@@ -130,7 +130,7 @@ export function Foo({ children }) {
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 export function Foo({ children }) {

--- a/tests/v3-test/typescript/binary-operator/fixtures.ts
+++ b/tests/v3-test/typescript/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v3-test/typescript/binary-operator/ideal.test.ts
+++ b/tests/v3-test/typescript/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/binary-operator/relative.test.ts
+++ b/tests/v3-test/typescript/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,186 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/absolute.test.ts.snap
@@ -19,7 +19,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -62,7 +62,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -81,7 +81,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -102,7 +102,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -124,7 +124,7 @@ adipiscing elit proin ex massa hendrerit eu posuere\`)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -143,7 +143,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -163,7 +163,7 @@ elit proin ex massa hendrerit eu posuere\`
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v3-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -19,7 +19,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -64,7 +64,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -83,7 +83,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -104,7 +104,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -128,7 +128,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -147,7 +147,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -167,7 +167,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v3-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,192 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`
+          : \`lorem ipsum dolor sit amet consectetur
+            adipiscing elit proin ex massa hendrerit eu
+            posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,186 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        'lorem ipsum dolor sit amet' !==
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' &&
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        truthyExpression &&
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        'lorem ipsum dolor sit amet' ===
+          'consectetur adipiscing elit proin ex massa hendrerit eu posuere' ||
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        falsyExpression ||
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ??
+        \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere\`
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+"//---------------------------------------------------------|
+printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div
+      :class="
+        null ??
+        (condition
+          ? \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`
+          : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+            ex massa hendrerit eu posuere\`)
+      "
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/binary-operator/__snapshots__/relative.test.ts.snap
@@ -19,7 +19,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -40,7 +40,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -62,7 +62,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -81,7 +81,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -102,7 +102,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -124,7 +124,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
+exports[`'(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -143,7 +143,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 2`] = `
+exports[`'(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>
@@ -163,7 +163,7 @@ printWidth=60 (in snapshot)
 "
 `;
 
-exports[`'(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 3`] = `
+exports[`'(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.' > expectation 1`] = `
 "//---------------------------------------------------------|
 printWidth=60 (in snapshot)
 <template>

--- a/tests/v3-test/vue/binary-operator/absolute.test.ts
+++ b/tests/v3-test/vue/binary-operator/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/binary-operator/fixtures.ts
+++ b/tests/v3-test/vue/binary-operator/fixtures.ts
@@ -18,7 +18,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(2) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -34,7 +34,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    name: '(3) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -50,7 +50,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(4) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -66,7 +66,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(5) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -82,7 +82,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    name: '(6) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -98,7 +98,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(7) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -114,7 +114,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(8) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>
@@ -130,7 +130,7 @@ export const fixtures: Omit<Fixture, 'output'>[] = [
     },
   },
   {
-    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    name: '(9) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
     input: `
 //---------------------------------------------------------| printWidth=60 (in snapshot)
 <template>

--- a/tests/v3-test/vue/binary-operator/fixtures.ts
+++ b/tests/v3-test/vue/binary-operator/fixtures.ts
@@ -1,0 +1,148 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && 'lorem ipsum dolor sit amet' !== 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' && 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(1) When expressions are joined by the logical AND operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="truthyExpression && (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || 'lorem ipsum dolor sit amet' === 'consectetur adipiscing elit proin ex massa hendrerit eu posuere' || 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) When expressions are joined by the logical OR operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="falsyExpression || (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? void 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' ?? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) When expressions are joined by the nullish coalescing operator, line wrapping is supported only in the last operand.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+<template>
+  <div>
+    <div :class="null ?? (condition ? 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere' : 'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere')">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/v3-test/vue/binary-operator/ideal.test.ts
+++ b/tests/v3-test/vue/binary-operator/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/binary-operator/relative.test.ts
+++ b/tests/v3-test/vue/binary-operator/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR is preliminary work to address #68.