### PR TITLE
Further improves formatting of nested expressions

### DIFF
--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -172,7 +172,7 @@ function linearParse(
       [rangeStartOfParent, rangeEndOfParent] = parent.range;
 
       if (rangeEndOfParent < temporaryRangeEnd) {
-        if (parent.type === 'ternary') {
+        if (parent.type === 'ternary' || parent.type === 'logical') {
           textTokens.push({
             type: 'Placeholder',
             range: [rangeEndOfParent, temporaryRangeEnd],
@@ -196,7 +196,7 @@ function linearParse(
       body: formattedText.slice(rangeEndOfClassName + delimiterOffset, temporaryRangeEnd),
     });
 
-    if (type === 'ternary') {
+    if (type === 'ternary' || type === 'logical') {
       const ternaryExpression = formattedText.slice(rangeStartOfClassName, rangeEndOfClassName);
       const ternaryToken: TextToken = {
         type,
@@ -284,7 +284,7 @@ function linearParse(
   // Note: Since parent cannot be accessed directly outside of the for loop, I check for changes that may occur when parent exists.
   // if (parent)
   if (rangeStartOfParent) {
-    // if (parent.type === 'ternary')
+    // if (parent.type === 'ternary' || parent.type === 'logical')
     if (textTokens.find((token) => token.type === 'Text')!.body === '') {
       textTokens.push({
         type: 'Text',
@@ -334,7 +334,7 @@ function formatTokens(
   for (let tokenIndex = formattedTokens.length - 1; tokenIndex >= 0; tokenIndex -= 1) {
     const token = formattedTokens[tokenIndex];
 
-    if (token.type === 'ternary') {
+    if (token.type === 'ternary' || token.type === 'logical') {
       if (token.children?.length) {
         token.children = formatTokens(token.children, indentUnit, options);
       }
@@ -508,7 +508,7 @@ function unfreezeToken(token: TextToken, options: ResolvedOptions): string {
       const tokenOfChildren = token.children[index];
 
       if (tokenOfChildren.frozenClassName !== undefined) {
-        if (tokenOfChildren.type === 'ternary') {
+        if (tokenOfChildren.type === 'ternary' || tokenOfChildren.type === 'logical') {
           const plainText = unfreezeToken(tokenOfChildren, options);
           let replaceTarget: string | RegExp = tokenOfChildren.frozenClassName;
           let replaceValue = plainText;

--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -150,6 +150,7 @@ function linearParse(
   });
   const textTokens: TextToken[] = [];
   let temporaryRangeEnd = formattedText.length;
+  let typeOfParent: string | null = null;
   let rangeStartOfParent = 0;
   let rangeEndOfParent = formattedText.length;
 
@@ -169,6 +170,7 @@ function linearParse(
         : 0;
 
     if (parent) {
+      typeOfParent = parent.type;
       [rangeStartOfParent, rangeEndOfParent] = parent.range;
 
       if (rangeEndOfParent < temporaryRangeEnd) {
@@ -282,10 +284,8 @@ function linearParse(
   }
 
   // Note: Since parent cannot be accessed directly outside of the for loop, I check for changes that may occur when parent exists.
-  // if (parent)
-  if (rangeStartOfParent) {
-    // if (parent.type === 'ternary' || parent.type === 'logical')
-    if (textTokens.find((token) => token.type === 'Text')!.body === '') {
+  if (typeOfParent) {
+    if (typeOfParent === 'ternary' || typeOfParent === 'logical') {
       textTokens.push({
         type: 'Text',
         range: [rangeStartOfParent, temporaryRangeEnd],

--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -519,13 +519,21 @@ function unfreezeToken(token: TextToken, options: ResolvedOptions): string {
             ) !== null;
 
           if (isMultiLineBody) {
+            const isNestedExpressionClosedOnTheNextLine =
+              token.body.match(new RegExp(`${tokenOfChildren.frozenClassName}${EOL}`)) !== null;
+
             replaceTarget = new RegExp(
-              `[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}${EOL}?[${SPACE}${TAB}]*`,
+              `[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}${
+                isNestedExpressionClosedOnTheNextLine ? '' : `[${SPACE}${TAB}]*`
+              }`,
             );
             replaceValue = `${
               token.children[index - 1].body.match(new RegExp(`[${SPACE}${TAB}]*$`))![0]
             }${plainText}${
-              options.endingPosition === 'absolute'
+              // eslint-disable-next-line no-nested-ternary
+              isNestedExpressionClosedOnTheNextLine
+                ? ''
+                : options.endingPosition === 'absolute'
                 ? EOL
                 : token.children[index + 1].body.match(new RegExp(`^${EOL}[${SPACE}${TAB}]*`))![0]
             }`;

--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import type { NodeRange, ExpressionNode, ClassNameNode } from './shared';
-import { EOL, PH, SPACE, SINGLE_QUOTE, DOUBLE_QUOTE, BACKTICK } from './shared';
+import { EOL, PH, SPACE, TAB, SINGLE_QUOTE, DOUBLE_QUOTE, BACKTICK } from './shared';
 
 function sha1(input: string): string {
   return createHash('sha1').update(input).digest('hex');
@@ -511,8 +511,10 @@ function unfreezeToken(token: TextToken): string {
         if (tokenOfChildren.type === 'ternary') {
           // eslint-disable-next-line no-param-reassign
           token.body = token.body.replace(
-            tokenOfChildren.frozenClassName,
-            unfreezeToken(tokenOfChildren),
+            new RegExp(`[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}`),
+            `${
+              token.children[index - 1].body.match(new RegExp(`[${SPACE}${TAB}]*$`))![0]
+            }${unfreezeToken(tokenOfChildren)}`,
           );
         } else if (tokenOfChildren.type === 'expression') {
           const props = tokenOfChildren.props as Omit<ExpressionNode, 'range' | 'type'> & {

--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -513,21 +513,24 @@ function unfreezeToken(token: TextToken, options: ResolvedOptions): string {
           let replaceTarget: string | RegExp = tokenOfChildren.frozenClassName;
           let replaceValue = plainText;
 
-          const isMultiLineBody =
+          const isNestedExpressionOpenedOnThePreviousLine =
             token.body.match(
-              new RegExp(`${EOL}[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}`),
+              new RegExp(`\\$\\{${EOL}[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}`),
             ) !== null;
+          const isNestedExpressionClosedOnTheNextLine =
+            token.body.match(
+              new RegExp(`${tokenOfChildren.frozenClassName}${EOL}[${SPACE}${TAB}]*\\}`),
+            ) !== null;
+          const isMultiLineBody =
+            isNestedExpressionOpenedOnThePreviousLine || isNestedExpressionClosedOnTheNextLine;
 
           if (isMultiLineBody) {
-            const isNestedExpressionClosedOnTheNextLine =
-              token.body.match(new RegExp(`${tokenOfChildren.frozenClassName}${EOL}`)) !== null;
-
             replaceTarget = new RegExp(
               `[${SPACE}${TAB}]*${tokenOfChildren.frozenClassName}${
                 isNestedExpressionClosedOnTheNextLine ? '' : `[${SPACE}${TAB}]*`
               }`,
             );
-            replaceValue = `${
+            replaceValue = `${isNestedExpressionOpenedOnThePreviousLine ? '' : EOL}${
               token.children[index - 1].body.match(new RegExp(`[${SPACE}${TAB}]*$`))![0]
             }${plainText}${
               // eslint-disable-next-line no-nested-ternary

--- a/src/packages/core-parts/finder.ts
+++ b/src/packages/core-parts/finder.ts
@@ -788,6 +788,27 @@ export function findTargetClassNameNodes(ast: any, options: ResolvedOptions): Cl
             });
           }
         }
+
+        if (options.experimentalOptimization) {
+          if (
+            isTypeof(
+              node,
+              z.object({
+                loc: z.object({
+                  start: z.object({
+                    line: z.number(),
+                  }),
+                }),
+              }),
+            )
+          ) {
+            classNameNodes.push({
+              type: 'logical',
+              range: [currentNodeRangeStart, currentNodeRangeEnd],
+              startLineIndex: node.loc.start.line - 1,
+            });
+          }
+        }
         break;
       }
       case 'Block':
@@ -2845,6 +2866,27 @@ export function findTargetClassNameNodesForSvelte(
                 // eslint-disable-next-line no-param-reassign
                 classNameNode.range = [0, Infinity];
               }
+            });
+          }
+        }
+
+        if (options.experimentalOptimization) {
+          if (
+            isTypeof(
+              node,
+              z.object({
+                loc: z.object({
+                  start: z.object({
+                    line: z.number(),
+                  }),
+                }),
+              }),
+            )
+          ) {
+            classNameNodes.push({
+              type: 'logical',
+              range: [currentNodeRangeStart, currentNodeRangeEnd],
+              startLineIndex: node.loc.start.line - 1,
             });
           }
         }

--- a/src/packages/core-parts/shared.ts
+++ b/src/packages/core-parts/shared.ts
@@ -86,10 +86,10 @@ export type ExpressionNode = ClassNameNodeBase & {
 };
 
 /**
- * In fact, the ternary operator itself is not a class name node, but it defines a type as an exception because it needs to be frozen when processing complex expressions.
+ * In fact, these expressions themselves are not class name nodes, but it defines their type as exceptions because it needs to be frozen when processing complex expressions.
  */
-type TernaryExpressionNode = ClassNameNodeBase & {
-  type: 'ternary';
+type PreservingExpressionNode = ClassNameNodeBase & {
+  type: 'ternary' | 'logical';
 };
 
-export type ClassNameNode = UnknownNode | AttributeNode | ExpressionNode | TernaryExpressionNode;
+export type ClassNameNode = UnknownNode | AttributeNode | ExpressionNode | PreservingExpressionNode;

--- a/tests/v2-test/astro/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v2-test/astro/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v2-test/astro/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v2-test/astro/issue-39/absolute.test.ts
+++ b/tests/v2-test/astro/issue-39/absolute.test.ts
@@ -35,6 +35,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`,
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -60,6 +63,66 @@ text-white\`
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"}
+text-white\`
+      : "text-gray-900"
+}\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/astro/issue-39/ideal.test.ts
+++ b/tests/v2-test/astro/issue-39/ideal.test.ts
@@ -35,6 +35,9 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -60,6 +63,66 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"}
+        text-white\`
+      : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/astro/issue-39/relative.test.ts
+++ b/tests/v2-test/astro/issue-39/relative.test.ts
@@ -35,6 +35,9 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -59,6 +62,65 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+      : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/astro/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v2-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105
+        active:shadow-sm active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/issue-68/absolute.test.ts
+++ b/tests/v2-test/astro/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/issue-68/fixtures.ts
+++ b/tests/v2-test/astro/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  </div>
+</div>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/astro/issue-68/ideal.test.ts
+++ b/tests/v2-test/astro/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/issue-68/relative.test.ts
+++ b/tests/v2-test/astro/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v2-test/babel/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v2-test/babel/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v2-test/babel/issue-39/absolute.test.ts
+++ b/tests/v2-test/babel/issue-39/absolute.test.ts
@@ -45,6 +45,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+} text-white\`
+            : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/babel/issue-39/ideal.test.ts
+++ b/tests/v2-test/babel/issue-39/ideal.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+              } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/babel/issue-39/relative.test.ts
+++ b/tests/v2-test/babel/issue-39/relative.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -79,6 +82,85 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${ variant === "outline" && "border border-current !bg-transparent" }
+\${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -17,7 +17,7 @@ hover:shadow-md\`
 } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
-} \${ variant === "outline" && "border border-current !bg-transparent" }
+} \${variant === "outline" && "border border-current !bg-transparent"}
 \${className}\`}
     />
   );

--- a/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -15,11 +15,10 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
-          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
-        } \${
-          variant === "primary" &&
-          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
         } \${variant === "outline" && "border border-current !bg-transparent"}
         \${className}\`}
     />

--- a/tests/v2-test/babel/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -13,9 +13,9 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
               rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
         } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
-          variant === "primary" &&
-          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
-        } \${ variant === "outline" && "border border-current !bg-transparent" }
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
         \${className}\`}
     />
   );

--- a/tests/v2-test/babel/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${ variant === "outline" && "border border-current !bg-transparent" }
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/issue-68/absolute.test.ts
+++ b/tests/v2-test/babel/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-68/fixtures.ts
+++ b/tests/v2-test/babel/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/babel/issue-68/fixtures.ts
+++ b/tests/v2-test/babel/issue-68/fixtures.ts
@@ -2,7 +2,7 @@ import type { Fixture } from 'test-settings';
 
 export const fixtures: Omit<Fixture, 'output'>[] = [
   {
-    name: "(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
     input: `
 //-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {

--- a/tests/v2-test/babel/issue-68/ideal.test.ts
+++ b/tests/v2-test/babel/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/issue-68/relative.test.ts
+++ b/tests/v2-test/babel/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v2-test/svelte/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v2-test/svelte/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v2-test/svelte/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v2-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105
+        active:shadow-sm active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/issue-68/absolute.test.ts
+++ b/tests/v2-test/svelte/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/issue-68/fixtures.ts
+++ b/tests/v2-test/svelte/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  </div>
+</div>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/svelte/issue-68/ideal.test.ts
+++ b/tests/v2-test/svelte/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/issue-68/relative.test.ts
+++ b/tests/v2-test/svelte/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v2-test/typescript/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v2-test/typescript/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v2-test/typescript/issue-39/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-39/absolute.test.ts
@@ -45,6 +45,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+} text-white\`
+            : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/typescript/issue-39/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-39/ideal.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+              } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/typescript/issue-39/relative.test.ts
+++ b/tests/v2-test/typescript/issue-39/relative.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -79,6 +82,85 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/typescript/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+        variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v2-test/typescript/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/issue-68/absolute.test.ts
+++ b/tests/v2-test/typescript/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-68/fixtures.ts
+++ b/tests/v2-test/typescript/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/typescript/issue-68/ideal.test.ts
+++ b/tests/v2-test/typescript/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/issue-68/relative.test.ts
+++ b/tests/v2-test/typescript/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/complex-template/__snapshots__/absolute.test.ts.snap
@@ -207,7 +207,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       v-bind:class="\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? 'consectetur adipiscing elit proin'
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -225,7 +225,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       v-bind:class="\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? 'consectetur adipiscing elit proin'
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -244,7 +244,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? 'consectetur adipiscing elit proin'
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -264,7 +264,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? 'consectetur adipiscing elit proin'
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v2-test/vue/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/complex-template/__snapshots__/ideal.test.ts.snap
@@ -250,7 +250,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -271,7 +271,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v2-test/vue/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v2-test/vue/issue-39/absolute.test.ts
+++ b/tests/v2-test/vue/issue-39/absolute.test.ts
@@ -38,6 +38,9 @@ active ? 'bg-teal-600 text-white' : 'text-gray-900' }\`
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -70,6 +73,77 @@ active ? 'bg-teal-600 text-white' : 'text-gray-900' } text-white\`
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+}\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? 'bg-teal-600 text-white' : 'text-gray-900'
+} text-white\`
+            : 'text-gray-900'
+}\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/vue/issue-39/ideal.test.ts
+++ b/tests/v2-test/vue/issue-39/ideal.test.ts
@@ -38,6 +38,9 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -70,6 +73,77 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? 'bg-teal-600 text-white' : 'text-gray-900'
+              } text-white\`
+            : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/vue/issue-39/relative.test.ts
+++ b/tests/v2-test/vue/issue-39/relative.test.ts
@@ -38,6 +38,9 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -69,6 +72,75 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? 'bg-teal-600 text-white' : 'text-gray-900' } text-white\`
+            : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v2-test/vue/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === 'underline'
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1' } \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+} \${variant === 'outline' && 'border border-current !bg-transparent'}
+\${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === 'underline'
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
+        } \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+        } \${variant === 'outline' && 'border border-current !bg-transparent'}
+        \${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
@@ -16,7 +16,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
+        } \${
+        variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
         } \${
         variant === 'primary' &&
         'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'

--- a/tests/v2-test/vue/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1' } \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+        } \${variant === 'outline' && 'border border-current !bg-transparent'}
+        \${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/issue-68/absolute.test.ts
+++ b/tests/v2-test/vue/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/issue-68/fixtures.ts
+++ b/tests/v2-test/vue/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`"
+    />
+  </div>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v2-test/vue/issue-68/ideal.test.ts
+++ b/tests/v2-test/vue/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/issue-68/relative.test.ts
+++ b/tests/v2-test/vue/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v3-test/astro/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v3-test/astro/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v3-test/astro/issue-39/absolute.test.ts
+++ b/tests/v3-test/astro/issue-39/absolute.test.ts
@@ -35,6 +35,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`,
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -60,6 +63,66 @@ text-white\`
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"}
+text-white\`
+      : "text-gray-900"
+}\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/astro/issue-39/ideal.test.ts
+++ b/tests/v3-test/astro/issue-39/ideal.test.ts
@@ -35,6 +35,9 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -60,6 +63,66 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"}
+        text-white\`
+      : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/astro/issue-39/relative.test.ts
+++ b/tests/v3-test/astro/issue-39/relative.test.ts
@@ -35,6 +35,9 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -59,6 +62,65 @@ const combination = classNames(
 );
 ---
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+---
+import classNames from 'classnames'
+
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? "bg-teal-600 text-white"
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+import classNames from "classnames";
+
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active ? "bg-teal-600 text-white" : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+---
+const combination = classNames(
+    \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+        active
+            ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+            : "text-gray-900"
+    }\`
+)
+---
+`,
+    output: `---
+const combination = classNames(
+  \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+    active
+      ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+      : "text-gray-900"
+  }\`,
+);
+---
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/astro/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v3-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105
+        active:shadow-sm active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/issue-68/absolute.test.ts
+++ b/tests/v3-test/astro/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/issue-68/fixtures.ts
+++ b/tests/v3-test/astro/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  </div>
+</div>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/astro/issue-68/ideal.test.ts
+++ b/tests/v3-test/astro/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/issue-68/relative.test.ts
+++ b/tests/v3-test/astro/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v3-test/babel/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v3-test/babel/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v3-test/babel/issue-39/absolute.test.ts
+++ b/tests/v3-test/babel/issue-39/absolute.test.ts
@@ -45,6 +45,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+} text-white\`
+            : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/babel/issue-39/ideal.test.ts
+++ b/tests/v3-test/babel/issue-39/ideal.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+              } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/babel/issue-39/relative.test.ts
+++ b/tests/v3-test/babel/issue-39/relative.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -79,6 +82,85 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${ variant === "outline" && "border border-current !bg-transparent" }
+\${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -17,7 +17,7 @@ hover:shadow-md\`
 } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
         variant === "primary" &&
         "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
-} \${ variant === "outline" && "border border-current !bg-transparent" }
+} \${variant === "outline" && "border border-current !bg-transparent"}
 \${className}\`}
     />
   );

--- a/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -15,8 +15,7 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${
-          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v3-test/babel/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
 "//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {
   return (
@@ -15,7 +15,7 @@ export function Foo() {
         } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
-        } \${ variant === "outline" && "border border-current !bg-transparent" }
+        } \${variant === "outline" && "border border-current !bg-transparent"}
         \${className}\`}
     />
   );

--- a/tests/v3-test/babel/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${ variant === "outline" && "border border-current !bg-transparent" }
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/issue-68/absolute.test.ts
+++ b/tests/v3-test/babel/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-68/fixtures.ts
+++ b/tests/v3-test/babel/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/babel/issue-68/fixtures.ts
+++ b/tests/v3-test/babel/issue-68/fixtures.ts
@@ -2,7 +2,7 @@ import type { Fixture } from 'test-settings';
 
 export const fixtures: Omit<Fixture, 'output'>[] = [
   {
-    name: "(1) Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
     input: `
 //-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
 export function Foo() {

--- a/tests/v3-test/babel/issue-68/ideal.test.ts
+++ b/tests/v3-test/babel/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/issue-68/relative.test.ts
+++ b/tests/v3-test/babel/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       class={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v3-test/svelte/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v3-test/svelte/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       class={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v3-test/svelte/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v3-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105
+        active:shadow-sm active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/issue-68/absolute.test.ts
+++ b/tests/v3-test/svelte/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/issue-68/fixtures.ts
+++ b/tests/v3-test/svelte/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<div>
+  <div>
+    <Component
+      class={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  </div>
+</div>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/svelte/issue-68/ideal.test.ts
+++ b/tests/v3-test/svelte/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/issue-68/relative.test.ts
+++ b/tests/v3-test/svelte/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/complex-template/__snapshots__/absolute.test.ts.snap
@@ -203,7 +203,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -221,7 +221,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   return (
     <div
       className={\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? "consectetur adipiscing elit proin"
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? "consectetur adipiscing elit proin"
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v3-test/typescript/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/complex-template/__snapshots__/ideal.test.ts.snap
@@ -252,7 +252,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -273,7 +273,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v3-test/typescript/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       className={\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? "consectetur adipiscing elit proin"
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v3-test/typescript/issue-39/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-39/absolute.test.ts
@@ -45,6 +45,9 @@ active ? "bg-teal-600 text-white" : "text-gray-900" }\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+} text-white\`
+            : "text-gray-900"
+}\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/typescript/issue-39/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-39/ideal.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -80,6 +83,87 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? "bg-teal-600 text-white" : "text-gray-900"
+              } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/typescript/issue-39/relative.test.ts
+++ b/tests/v3-test/typescript/issue-39/relative.test.ts
@@ -45,6 +45,9 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -79,6 +82,85 @@ export default function ClassNameCb() {
   );
 }
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+import { Combobox } from "@headlessui/react"
+
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? "bg-teal-600 text-white"
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `import { Combobox } from "@headlessui/react";
+
+export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? "bg-teal-600 text-white" : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+export default function ClassNameCb() {
+    return (
+        <Combobox.Option
+            className={({ active }) =>
+                \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                    active
+                        ? \`bg-teal-600 \${active ? "bg-teal-600 text-white" : "text-gray-900"} text-white\`
+                        : "text-gray-900"
+                }\`
+            }
+            value={"test"}
+        ></Combobox.Option>
+    )
+}
+`,
+    output: `export default function ClassNameCb() {
+  return (
+    <Combobox.Option
+      className={({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? "bg-teal-600 text-white" : "text-gray-900" } text-white\`
+            : "text-gray-900"
+        }\`
+      }
+      value={"test"}
+    ></Combobox.Option>
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/typescript/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,26 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === "underline"
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+        variant === "primary" &&
+        "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+} \${variant === "outline" && "border border-current !bg-transparent"}
+\${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === "underline"
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/issue-68/__snapshots__/ideal.test.ts.snap
@@ -15,7 +15,8 @@ export function Foo() {
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
+        } \${
+          variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1"
         } \${
           variant === "primary" &&
           "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"

--- a/tests/v3-test/typescript/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === "underline"
+            ? "pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]"
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === "default" && "border border-bg-3 bg-bg-2 text-accent-1" } \${
+          variant === "primary" &&
+          "active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1"
+        } \${variant === "outline" && "border border-current !bg-transparent"}
+        \${className}\`}
+    />
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/issue-68/absolute.test.ts
+++ b/tests/v3-test/typescript/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-68/fixtures.ts
+++ b/tests/v3-test/typescript/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+export function Foo() {
+  return (
+    <Component
+      className={\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`}
+    />
+  );
+}
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/typescript/issue-68/ideal.test.ts
+++ b/tests/v3-test/typescript/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/issue-68/relative.test.ts
+++ b/tests/v3-test/typescript/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/complex-template/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/complex-template/__snapshots__/absolute.test.ts.snap
@@ -207,7 +207,7 @@ exports[`'(exp-5) nested expression - string literal ternary' > expectation 1`] 
   <div>
     <div
       v-bind:class="\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? 'consectetur adipiscing elit proin'
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -225,7 +225,7 @@ exports[`'(exp-6) nested expression - template literal ternary' > expectation 1`
   <div>
     <div
       v-bind:class="\`lorem ipsum dolor sit amet \${
-condition
+        condition
           ? 'consectetur adipiscing elit proin'
           : \`lorem ipsum dolor sit amet consectetur
 adipiscing elit proin ex massa hendrerit eu posuere\`
@@ -244,7 +244,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? 'consectetur adipiscing elit proin'
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`
@@ -264,7 +264,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
 \${\`lorem ipsum dolor sit amet \${
-condition
+  condition
     ? 'consectetur adipiscing elit proin'
     : \`lorem ipsum dolor sit amet consectetur adipiscing
 elit proin ex massa hendrerit eu posuere\`

--- a/tests/v3-test/vue/complex-template/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/complex-template/__snapshots__/ideal.test.ts.snap
@@ -250,7 +250,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu
@@ -271,7 +271,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur
               adipiscing elit proin ex massa hendrerit eu

--- a/tests/v3-test/vue/complex-template/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/complex-template/__snapshots__/relative.test.ts.snap
@@ -240,7 +240,7 @@ exports[`'(exp-7) double nested expression - string literal ternary' > expectati
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`
@@ -260,7 +260,7 @@ exports[`'(exp-8) double nested expression - template literal ternary' > expecta
     <div
       v-bind:class="\`lorem ipsum dolor sit amet
         \${\`lorem ipsum dolor sit amet \${
-        condition
+          condition
             ? 'consectetur adipiscing elit proin'
             : \`lorem ipsum dolor sit amet consectetur adipiscing elit proin
               ex massa hendrerit eu posuere\`

--- a/tests/v3-test/vue/issue-39/absolute.test.ts
+++ b/tests/v3-test/vue/issue-39/absolute.test.ts
@@ -38,6 +38,9 @@ active ? 'bg-teal-600 text-white' : 'text-gray-900' }\`
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -70,6 +73,77 @@ active ? 'bg-teal-600 text-white' : 'text-gray-900' } text-white\`
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+}\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? 'bg-teal-600 text-white' : 'text-gray-900'
+} text-white\`
+            : 'text-gray-900'
+}\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/vue/issue-39/ideal.test.ts
+++ b/tests/v3-test/vue/issue-39/ideal.test.ts
@@ -38,6 +38,9 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -70,6 +73,77 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${
+                active ? 'bg-teal-600 text-white' : 'text-gray-900'
+              } text-white\`
+            : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/vue/issue-39/relative.test.ts
+++ b/tests/v3-test/vue/issue-39/relative.test.ts
@@ -38,6 +38,9 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
   },
   {
     name: 'double nested expression in template literal',
@@ -69,6 +72,75 @@ const fixtures: Fixture[] = [
   ></Combobox.Option>
 </template>
 `,
+    options: {
+      experimentalOptimization: false,
+    },
+  },
+  {
+    name: '(exp-1) nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? 'bg-teal-600 text-white'
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active ? 'bg-teal-600 text-white' : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+  {
+    name: '(exp-2) double nested expression in template literal',
+    input: `
+<template>
+    <Combobox.Option
+        :class="({ active }) =>
+            \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+                active
+                    ? \`bg-teal-600 \${active ? 'bg-teal-600 text-white' : 'text-gray-900'} text-white\`
+                    : 'text-gray-900'
+            }\`
+        "
+        :value="'test'"
+    ></Combobox.Option>
+</template>
+`,
+    output: `<template>
+  <Combobox.Option
+    :class="
+      ({ active }) =>
+        \`relative cursor-default select-none py-2 pl-10 pr-4 \${
+          active
+            ? \`bg-teal-600 \${ active ? 'bg-teal-600 text-white' : 'text-gray-900' } text-white\`
+            : 'text-gray-900'
+        }\`
+    "
+    :value="'test'"
+  ></Combobox.Option>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
   },
 ];
 

--- a/tests/v3-test/vue/issue-68/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/issue-68/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9]
+tracking-widest transition-all duration-500 ease-out hover:brightness-105
+active:shadow-sm active:brightness-110 active:transition-none \${
+        variant === 'underline'
+          ? \`pb-2 text-accent-1 underline underline-offset-8
+hover:underline-offset-[10px]\`
+          : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5 text-center
+hover:shadow-md\`
+} \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1' } \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+} \${variant === 'outline' && 'border border-current !bg-transparent'}
+\${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
@@ -16,7 +16,8 @@ printWidth=80 (in snapshot)
             : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
               overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
               text-center hover:shadow-md\`
-        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
+        } \${
+          variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
         } \${
           variant === 'primary' &&
           'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'

--- a/tests/v3-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/issue-68/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9]
+        tracking-widest transition-all duration-500 ease-out
+        hover:brightness-105 active:shadow-sm active:brightness-110
+        active:transition-none \${
+          variant === 'underline'
+            ? \`pb-2 text-accent-1 underline underline-offset-8
+              hover:underline-offset-[10px]\`
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2
+              overflow-hidden rounded px-[max(1.5rem,_var(--radius))] py-5
+              text-center hover:shadow-md\`
+        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'
+        } \${
+          variant === 'primary' &&
+          'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+        } \${variant === 'outline' && 'border border-current !bg-transparent'}
+        \${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-68/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/issue-68/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,25 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier\\'s output as much as possible.' > expectation 1`] = `
+"//-----------------------------------------------------------------------------|
+printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+          variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${ variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1' } \${
+          variant === 'primary' &&
+          'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1'
+        } \${variant === 'outline' && 'border border-current !bg-transparent'}
+        \${className}\`"
+    />
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/issue-68/absolute.test.ts
+++ b/tests/v3-test/vue/issue-68/absolute.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/issue-68/fixtures.ts
+++ b/tests/v3-test/vue/issue-68/fixtures.ts
@@ -1,0 +1,30 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: "(1) 🟠 Even when nested expressions contain logical expressions, the opening and closing braces and nested indentation of the expressions should be preserved in Prettier's output as much as possible.",
+    input: `
+//-----------------------------------------------------------------------------| printWidth=80 (in snapshot)
+<template>
+  <div>
+    <Component
+      :class="\`relative text-sm font-bold uppercase leading-[0.9] tracking-widest
+        transition-all duration-500 ease-out hover:brightness-105 active:shadow-sm
+        active:brightness-110 active:transition-none \${
+        variant === 'underline'
+            ? 'pb-2 text-accent-1 underline underline-offset-8 hover:underline-offset-[10px]'
+            : \`flex min-h-10 w-max min-w-28 items-center justify-between gap-2 overflow-hidden
+              rounded px-[max(1.5rem,_var(--radius))] py-5 text-center hover:shadow-md\`
+        } \${variant === 'default' && 'border border-bg-3 bg-bg-2 text-accent-1'} \${
+        variant === 'primary' &&
+        'active:accent-1 border border-accent-2 !bg-accent-1 text-bg-1' } \${ variant ===
+        'outline' && 'border border-current !bg-transparent' } \${className}\`"
+    />
+  </div>
+</template>
+`,
+    options: {
+      experimentalOptimization: true,
+    },
+  },
+];

--- a/tests/v3-test/vue/issue-68/ideal.test.ts
+++ b/tests/v3-test/vue/issue-68/ideal.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/issue-68/relative.test.ts
+++ b/tests/v3-test/vue/issue-68/relative.test.ts
@@ -1,0 +1,13 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR closes #68.

This feature is enabled by turning on the `experimentalOptimization` option.

When a ternary operator or a logical expression is included in a nested expression, the indentation of the line they start on is no longer affected by the `endingPosition` option, and is preserved as much as possible in Prettier's output.