### PR TITLE
Add new option `syntaxTransformation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ Default | CLI&nbsp;Override | API&nbsp;Override
 --- | --- | ---
 `false` | `--experimental-optimization` | `experimentalOptimization: <boolean>`
 
+### Syntax Transformation
+
+First available in v0.7.7.
+
+If a line wrapping occurs in a class name written in non-expression syntax, it is transformed into expression syntax. This transformation does not support reversible formatting.
+
+<!-- prettier-ignore -->
+Default | CLI&nbsp;Override | API&nbsp;Override
+--- | --- | ---
+`false` | `--syntax-transformation` | `syntaxTransformation: <boolean>`
+
 ## Version correlation with sibling plugins
 
 Starting with `0.6.0`, when there is a minor release on one side, I plan to reflect that change on the other side as well if possible.

--- a/global.d.ts
+++ b/global.d.ts
@@ -30,6 +30,7 @@ declare global {
     endingPosition: 'relative' | 'absolute' | 'absolute-with-indent';
     debugFlag: boolean;
     experimentalOptimization: boolean;
+    delimiterTransformation: boolean;
   };
 
   type ResolvedOptions = PrettierBaseOptions & { parser: unknown } & ThisPluginOptions;

--- a/global.d.ts
+++ b/global.d.ts
@@ -30,7 +30,7 @@ declare global {
     endingPosition: 'relative' | 'absolute' | 'absolute-with-indent';
     debugFlag: boolean;
     experimentalOptimization: boolean;
-    delimiterTransformation: boolean;
+    syntaxTransformation: boolean;
   };
 
   type ResolvedOptions = PrettierBaseOptions & { parser: unknown } & ThisPluginOptions;

--- a/src/packages/core-parts/experimental.ts
+++ b/src/packages/core-parts/experimental.ts
@@ -375,6 +375,35 @@ function formatTokens(
       }
       formattedClassName = formattedClassName.slice(0, -trailingDelimiter.length || undefined);
 
+      if (isMultiLineClassName && options.syntaxTransformation) {
+        switch (options.parser) {
+          case 'babel':
+          case 'typescript':
+          case 'astro':
+          case 'svelte': {
+            formattedTokens[tokenIndex - 1].body = `{${BACKTICK}`;
+            formattedTokens[tokenIndex + 1].body = `${BACKTICK}}`;
+
+            formattedClassName = formattedClassName.replace(/`/g, `\\${BACKTICK}`);
+            break;
+          }
+          case 'vue': {
+            formattedTokens[tokenIndex - 2].body = formattedTokens[tokenIndex - 2].body.replace(
+              /([^ :=]+=)$/,
+              ':$1',
+            );
+            formattedTokens[tokenIndex - 1].body = `${DOUBLE_QUOTE}${BACKTICK}`;
+            formattedTokens[tokenIndex + 1].body = `${BACKTICK}${DOUBLE_QUOTE}`;
+
+            formattedClassName = formattedClassName.replace(/`/g, `\\${BACKTICK}`);
+            break;
+          }
+          default: {
+            break;
+          }
+        }
+      }
+
       token.body = formattedClassName;
     } else if (token.type === 'expression') {
       const props = token.props as Omit<ExpressionNode, 'range' | 'type'> & {

--- a/src/packages/core-parts/index.ts
+++ b/src/packages/core-parts/index.ts
@@ -369,15 +369,37 @@ function replaceClassName({
         classNameNode.isItAnObjectProperty
           ? 1
           : 0;
-      const classNamePartialWrappedText = `${formattedPrevText.slice(
-        0,
-        classNameNodeRangeStart - sliceOffset + (isAttributeType ? 1 : 0),
-      )}${substitute}${
-        isAttributeType
-          ? formattedPrevText.slice(
-              correctedRangeEnd + sliceOffset - 1,
-              correctedRangeEnd + sliceOffset,
+      const conditionForSyntaxTransformation =
+        isMultiLineClassName &&
+        options.syntaxTransformation &&
+        ['babel', 'typescript', 'astro', 'svelte', 'vue'].includes(options.parser as string);
+      const classNamePartialWrappedText = `${
+        isAttributeType && conditionForSyntaxTransformation && options.parser === 'vue'
+          ? formattedPrevText
+              .slice(0, classNameNodeRangeStart - sliceOffset)
+              .replace(/([^ :=]+=)$/, ':$1')
+          : formattedPrevText.slice(
+              0,
+              classNameNodeRangeStart -
+                sliceOffset +
+                (isAttributeType && !conditionForSyntaxTransformation ? 1 : 0),
             )
+      }${
+        isAttributeType && conditionForSyntaxTransformation
+          ? options.parser === 'vue'
+            ? `${DOUBLE_QUOTE}${BACKTICK}`
+            : `{${BACKTICK}`
+          : ''
+      }${substitute}${
+        isAttributeType
+          ? conditionForSyntaxTransformation
+            ? options.parser === 'vue'
+              ? `${BACKTICK}${DOUBLE_QUOTE}`
+              : `${BACKTICK}}`
+            : formattedPrevText.slice(
+                correctedRangeEnd + sliceOffset - 1,
+                correctedRangeEnd + sliceOffset,
+              )
           : ''
       }${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
 
@@ -709,15 +731,37 @@ async function replaceClassNameAsync({
         classNameNode.isItAnObjectProperty
           ? 1
           : 0;
-      const classNamePartialWrappedText = `${formattedPrevText.slice(
-        0,
-        classNameNodeRangeStart - sliceOffset + (isAttributeType ? 1 : 0),
-      )}${substitute}${
-        isAttributeType
-          ? formattedPrevText.slice(
-              correctedRangeEnd + sliceOffset - 1,
-              correctedRangeEnd + sliceOffset,
+      const conditionForSyntaxTransformation =
+        isMultiLineClassName &&
+        options.syntaxTransformation &&
+        ['babel', 'typescript', 'astro', 'svelte', 'vue'].includes(options.parser as string);
+      const classNamePartialWrappedText = `${
+        isAttributeType && conditionForSyntaxTransformation && options.parser === 'vue'
+          ? formattedPrevText
+              .slice(0, classNameNodeRangeStart - sliceOffset)
+              .replace(/([^ :=]+=)$/, ':$1')
+          : formattedPrevText.slice(
+              0,
+              classNameNodeRangeStart -
+                sliceOffset +
+                (isAttributeType && !conditionForSyntaxTransformation ? 1 : 0),
             )
+      }${
+        isAttributeType && conditionForSyntaxTransformation
+          ? options.parser === 'vue'
+            ? `${DOUBLE_QUOTE}${BACKTICK}`
+            : `{${BACKTICK}`
+          : ''
+      }${substitute}${
+        isAttributeType
+          ? conditionForSyntaxTransformation
+            ? options.parser === 'vue'
+              ? `${BACKTICK}${DOUBLE_QUOTE}`
+              : `${BACKTICK}}`
+            : formattedPrevText.slice(
+                correctedRangeEnd + sliceOffset - 1,
+                correctedRangeEnd + sliceOffset,
+              )
           : ''
       }${formattedPrevText.slice(correctedRangeEnd + sliceOffset)}`;
 

--- a/src/packages/v2-plugin/options.ts
+++ b/src/packages/v2-plugin/options.ts
@@ -59,7 +59,7 @@ export const options: SupportOptions = {
     description:
       'Formatting will be up to 67% faster. Note that Node.js version must be 17 or higher, and the output of nested expressions may be slightly different.',
   },
-  delimiterTransformation: {
+  syntaxTransformation: {
     since: '0.7.7',
     type: 'boolean',
     category: 'Format',

--- a/src/packages/v2-plugin/options.ts
+++ b/src/packages/v2-plugin/options.ts
@@ -59,4 +59,12 @@ export const options: SupportOptions = {
     description:
       'Formatting will be up to 67% faster. Note that Node.js version must be 17 or higher, and the output of nested expressions may be slightly different.',
   },
+  delimiterTransformation: {
+    since: '0.7.7',
+    type: 'boolean',
+    category: 'Format',
+    default: false,
+    description:
+      'If a line wrapping occurs in a class name written in non-expression syntax, it is transformed into expression syntax. This transformation does not support reversible formatting.',
+  },
 };

--- a/src/packages/v3-plugin/options.ts
+++ b/src/packages/v3-plugin/options.ts
@@ -64,7 +64,7 @@ export const options: SupportOptions = {
     description:
       'Formatting will be up to 67% faster. Note that Node.js version must be 17 or higher, and the output of nested expressions may be slightly different.',
   },
-  delimiterTransformation: {
+  syntaxTransformation: {
     // @ts-ignore
     since: '0.7.7',
     type: 'boolean',

--- a/src/packages/v3-plugin/options.ts
+++ b/src/packages/v3-plugin/options.ts
@@ -64,4 +64,13 @@ export const options: SupportOptions = {
     description:
       'Formatting will be up to 67% faster. Note that Node.js version must be 17 or higher, and the output of nested expressions may be slightly different.',
   },
+  delimiterTransformation: {
+    // @ts-ignore
+    since: '0.7.7',
+    type: 'boolean',
+    category: 'Format',
+    default: false,
+    description:
+      'If a line wrapping occurs in a class name written in non-expression syntax, it is transformed into expression syntax. This transformation does not support reversible formatting.',
+  },
 };

--- a/tests/v2-test/astro/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/astro/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/astro/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/astro/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/astro/syntax-transformation/absolute.test.ts
+++ b/tests/v2-test/astro/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/syntax-transformation/fixtures.ts
+++ b/tests/v2-test/astro/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={\`lorem ipsum dolor sit amet\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v2-test/astro/syntax-transformation/ideal.test.ts
+++ b/tests/v2-test/astro/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/astro/syntax-transformation/relative.test.ts
+++ b/tests/v2-test/astro/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/babel/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/babel/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/babel/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/babel/syntax-transformation/absolute.test.ts
+++ b/tests/v2-test/babel/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/syntax-transformation/fixtures.ts
+++ b/tests/v2-test/babel/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={\`lorem ipsum dolor sit amet\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v2-test/babel/syntax-transformation/ideal.test.ts
+++ b/tests/v2-test/babel/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/babel/syntax-transformation/relative.test.ts
+++ b/tests/v2-test/babel/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/svelte/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/svelte/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/svelte/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v2-test/svelte/syntax-transformation/absolute.test.ts
+++ b/tests/v2-test/svelte/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/syntax-transformation/fixtures.ts
+++ b/tests/v2-test/svelte/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={\`lorem ipsum dolor sit amet\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v2-test/svelte/syntax-transformation/ideal.test.ts
+++ b/tests/v2-test/svelte/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/svelte/syntax-transformation/relative.test.ts
+++ b/tests/v2-test/svelte/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/typescript/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/typescript/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/typescript/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v2-test/typescript/syntax-transformation/absolute.test.ts
+++ b/tests/v2-test/typescript/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/syntax-transformation/fixtures.ts
+++ b/tests/v2-test/typescript/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={\`lorem ipsum dolor sit amet\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v2-test/typescript/syntax-transformation/ideal.test.ts
+++ b/tests/v2-test/typescript/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/typescript/syntax-transformation/relative.test.ts
+++ b/tests/v2-test/typescript/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v2-test/vue/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v2-test/vue/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v2-test/vue/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v2-test/vue/syntax-transformation/absolute.test.ts
+++ b/tests/v2-test/vue/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/syntax-transformation/fixtures.ts
+++ b/tests/v2-test/vue/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="\`lorem ipsum dolor sit amet\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v2-test/vue/syntax-transformation/ideal.test.ts
+++ b/tests/v2-test/vue/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v2-test/vue/syntax-transformation/relative.test.ts
+++ b/tests/v2-test/vue/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/astro/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/astro/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/astro/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/astro/syntax-transformation/absolute.test.ts
+++ b/tests/v3-test/astro/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/syntax-transformation/fixtures.ts
+++ b/tests/v3-test/astro/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={\`lorem ipsum dolor sit amet\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v3-test/astro/syntax-transformation/ideal.test.ts
+++ b/tests/v3-test/astro/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/astro/syntax-transformation/relative.test.ts
+++ b/tests/v3-test/astro/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-astro', thisPlugin],
+  parser: 'astro',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/babel/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/babel/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/babel/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/babel/syntax-transformation/absolute.test.ts
+++ b/tests/v3-test/babel/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/syntax-transformation/fixtures.ts
+++ b/tests/v3-test/babel/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={\`lorem ipsum dolor sit amet\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v3-test/babel/syntax-transformation/ideal.test.ts
+++ b/tests/v3-test/babel/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/babel/syntax-transformation/relative.test.ts
+++ b/tests/v3-test/babel/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'babel',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/svelte/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/svelte/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/svelte/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div
+      class={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={"lorem ipsum dolor sit amet"}>
+      <slot />
+    </div>
+  </div>
+</div>
+"
+`;

--- a/tests/v3-test/svelte/syntax-transformation/absolute.test.ts
+++ b/tests/v3-test/svelte/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/syntax-transformation/fixtures.ts
+++ b/tests/v3-test/svelte/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<div>
+  <div>
+    <div class={\`lorem ipsum dolor sit amet\`}>
+      <slot />
+    </div>
+  </div>
+</div>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v3-test/svelte/syntax-transformation/ideal.test.ts
+++ b/tests/v3-test/svelte/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/svelte/syntax-transformation/relative.test.ts
+++ b/tests/v3-test/svelte/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: ['prettier-plugin-svelte', thisPlugin],
+  parser: 'svelte',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/typescript/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/typescript/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/typescript/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div
+      className={\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`}
+    >
+      {children}
+    </div>
+  );
+}
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={"lorem ipsum dolor sit amet"}>
+      {children}
+    </div>
+  );
+}
+"
+`;

--- a/tests/v3-test/typescript/syntax-transformation/absolute.test.ts
+++ b/tests/v3-test/typescript/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/syntax-transformation/fixtures.ts
+++ b/tests/v3-test/typescript/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+//---------------------------------------------------------| printWidth=60 (in snapshot)
+export function Foo({ children }) {
+  return (
+    <div className={\`lorem ipsum dolor sit amet\`}>
+      {children}
+    </div>
+  );
+}
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v3-test/typescript/syntax-transformation/ideal.test.ts
+++ b/tests/v3-test/typescript/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/typescript/syntax-transformation/relative.test.ts
+++ b/tests/v3-test/typescript/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'typescript',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/syntax-transformation/__snapshots__/absolute.test.ts.snap
+++ b/tests/v3-test/vue/syntax-transformation/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur
+adipiscing elit proin ex massa hendrerit eu posuere eu
+volutpat id neque pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/syntax-transformation/__snapshots__/ideal.test.ts.snap
+++ b/tests/v3-test/vue/syntax-transformation/__snapshots__/ideal.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur
+        adipiscing elit proin ex massa hendrerit eu posuere
+        eu volutpat id neque pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/syntax-transformation/__snapshots__/relative.test.ts.snap
+++ b/tests/v3-test/vue/syntax-transformation/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,41 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) Short enough class names do not cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(2) Long enough class names cause syntactic transformations.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div
+      :class="\`lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere eu volutpat id neque
+        pellentesque\`"
+    >
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;
+
+exports[`'(3) This transformation does not support reversible formatting.' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="'lorem ipsum dolor sit amet'">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+"
+`;

--- a/tests/v3-test/vue/syntax-transformation/absolute.test.ts
+++ b/tests/v3-test/vue/syntax-transformation/absolute.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/syntax-transformation/fixtures.ts
+++ b/tests/v3-test/vue/syntax-transformation/fixtures.ts
@@ -1,0 +1,52 @@
+import type { Fixture } from 'test-settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) Short enough class names do not cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(2) Long enough class names cause syntactic transformations.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+  {
+    name: '(3) This transformation does not support reversible formatting.',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+<template>
+  <div>
+    <div :class="\`lorem ipsum dolor sit amet\`">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+`,
+    options: {
+      syntaxTransformation: true,
+    },
+  },
+];

--- a/tests/v3-test/vue/syntax-transformation/ideal.test.ts
+++ b/tests/v3-test/vue/syntax-transformation/ideal.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'absolute-with-indent',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/v3-test/vue/syntax-transformation/relative.test.ts
+++ b/tests/v3-test/vue/syntax-transformation/relative.test.ts
@@ -1,0 +1,14 @@
+import { baseOptions } from 'test-settings';
+
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'vue',
+  printWidth: 60,
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR closes #74.

## What option is this?

Modern web libraries (or frameworks) compile source code to produce output. However, for some compilers, writing a multi-line class name without using an expression will result in a compilation error. (e.g. https://github.com/withastro/compiler/issues/1047)

This option avoids such compilation errors by transforming non-expression class names into expressions.

## What options are available?

### `false`

Non-expression multi-line class names are not transformed. This is the default option for backward compatibility reasons.

### `true`

Transform non-expression multi-line class names into expressions. This transformation does not support reversible formatting.