### PR TITLE
Fix line wrapping in class names passed as function arguments

### DIFF
--- a/src/core-parts/finder.ts
+++ b/src/core-parts/finder.ts
@@ -144,7 +144,8 @@ export function findTargetClassNameNodes(ast: AST, options: ResolvedOptions): Cl
       }
       case 'ArrowFunctionExpression':
       case 'BlockStatement':
-      case 'FunctionDeclaration': {
+      case 'FunctionDeclaration':
+      case 'FunctionExpression': {
         recursiveProps = ['body'];
         break;
       }

--- a/tests/babel/others/absolute.test.ts
+++ b/tests/babel/others/absolute.test.ts
@@ -269,6 +269,32 @@ export function Foo({ children }) {
 }
 `,
   },
+  {
+    name: 'class name passed as a function argument',
+    input: `
+const Foo = forwardRef(function Foo() {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      content
+    </div>
+  );
+});
+`,
+    output: `const Foo = forwardRef(function Foo() {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex
+        massa hendrerit eu posuere eu volutpat id neque pellentesque"
+    >
+      content
+    </div>
+  );
+});
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/babel/others/relative.test.ts
+++ b/tests/babel/others/relative.test.ts
@@ -264,6 +264,32 @@ export function Foo({ children }) {
 }
 `,
   },
+  {
+    name: 'class name passed as a function argument',
+    input: `
+const Foo = forwardRef(function Foo() {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      content
+    </div>
+  );
+});
+`,
+    output: `const Foo = forwardRef(function Foo() {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+        eu posuere eu volutpat id neque pellentesque"
+    >
+      content
+    </div>
+  );
+});
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/absolute.test.ts
+++ b/tests/typescript/others/absolute.test.ts
@@ -269,6 +269,32 @@ export function Foo({ children }) {
 }
 `,
   },
+  {
+    name: 'class name passed as a function argument',
+    input: `
+const Foo = forwardRef(function Foo() {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      content
+    </div>
+  );
+});
+`,
+    output: `const Foo = forwardRef(function Foo() {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex
+        massa hendrerit eu posuere eu volutpat id neque pellentesque"
+    >
+      content
+    </div>
+  );
+});
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/relative.test.ts
+++ b/tests/typescript/others/relative.test.ts
@@ -264,6 +264,32 @@ export function Foo({ children }) {
 }
 `,
   },
+  {
+    name: 'class name passed as a function argument',
+    input: `
+const Foo = forwardRef(function Foo() {
+  return (
+    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+      content
+    </div>
+  );
+});
+`,
+    output: `const Foo = forwardRef(function Foo() {
+  return (
+    <div
+      className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+        eu posuere eu volutpat id neque pellentesque"
+    >
+      content
+    </div>
+  );
+});
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);


### PR DESCRIPTION
```javascript
// Input
const Foo = forwardRef(function Foo() {
  return (
    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
      content
    </div>
  );
});

// prettier-plugin-classnames 0.8.0
const Foo = forwardRef(function Foo() {
  return (
    <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
      content
    </div>
  );
});

// prettier-plugin-classnames 0.8.1
const Foo = forwardRef(function Foo() {
  return (
    <div
      className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex
        massa hendrerit eu posuere eu volutpat id neque pellentesque"
    >
      content
    </div>
  );
});
```