### PR TITLE
Fix line wrapping inside 'if' blocks

### DIFF
--- a/src/core-parts/finder.ts
+++ b/src/core-parts/finder.ts
@@ -162,7 +162,8 @@ export function findTargetClassNameNodes(ast: AST, options: ResolvedOptions): Cl
         recursiveProps = ['arguments'];
         break;
       }
-      case 'ConditionalExpression': {
+      case 'ConditionalExpression':
+      case 'IfStatement': {
         recursiveProps = ['consequent', 'alternate'];
         break;
       }

--- a/tests/babel/others/absolute.test.ts
+++ b/tests/babel/others/absolute.test.ts
@@ -295,6 +295,40 @@ const Foo = forwardRef(function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: "class name inside the 'if' block",
+    input: `
+function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    output: `function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div
+        className="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+          ex massa hendrerit eu posuere eu volutpat id neque pellentesque"
+      >
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/babel/others/relative.test.ts
+++ b/tests/babel/others/relative.test.ts
@@ -290,6 +290,40 @@ const Foo = forwardRef(function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: "class name inside the 'if' block",
+    input: `
+function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    output: `function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div
+        className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+          eu posuere eu volutpat id neque pellentesque"
+      >
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/absolute.test.ts
+++ b/tests/typescript/others/absolute.test.ts
@@ -295,6 +295,40 @@ const Foo = forwardRef(function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: "class name inside the 'if' block",
+    input: `
+function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    output: `function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div
+        className="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+          ex massa hendrerit eu posuere eu volutpat id neque pellentesque"
+      >
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/relative.test.ts
+++ b/tests/typescript/others/relative.test.ts
@@ -290,6 +290,40 @@ const Foo = forwardRef(function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: "class name inside the 'if' block",
+    input: `
+function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    output: `function Foo() {
+  let elem;
+  if (true) {
+    elem = (
+      <div
+        className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+          eu posuere eu volutpat id neque pellentesque"
+      >
+        content
+      </div>
+    );
+  }
+  return elem;
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);


### PR DESCRIPTION
```javascript
// Input
function Foo() {
  let elem;
  if (true) {
    elem = (
      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
        content
      </div>
    );
  }
  return elem;
}

// prettier-plugin-classnames 0.8.0
function Foo() {
  let elem;
  if (true) {
    elem = (
      <div className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
        content
      </div>
    );
  }
  return elem;
}

// prettier-plugin-classnames 0.8.1
function Foo() {
  let elem;
  if (true) {
    elem = (
      <div
        className="lorem ipsum dolor sit amet consectetur adipiscing elit proin
          ex massa hendrerit eu posuere eu volutpat id neque pellentesque"
      >
        content
      </div>
    );
  }
  return elem;
}
```