### PR TITLE
Fix line wrapping in JSX mapped from object references that include optional chaining

### DIFF
--- a/src/core-parts/finder.ts
+++ b/src/core-parts/finder.ts
@@ -158,18 +158,20 @@ export function findTargetClassNameNodes(ast: AST, options: ResolvedOptions): Cl
         recursiveProps = ['left', 'right'];
         break;
       }
-      case 'CallExpression': {
+      case 'CallExpression':
+      case 'OptionalCallExpression': {
         recursiveProps = ['arguments'];
+        break;
+      }
+      case 'ChainExpression':
+      case 'ExpressionStatement':
+      case 'JSXExpressionContainer': {
+        recursiveProps = ['expression'];
         break;
       }
       case 'ConditionalExpression':
       case 'IfStatement': {
         recursiveProps = ['consequent', 'alternate'];
-        break;
-      }
-      case 'ExpressionStatement':
-      case 'JSXExpressionContainer': {
-        recursiveProps = ['expression'];
         break;
       }
       case 'ExportDefaultDeclaration':

--- a/tests/babel/others/absolute.test.ts
+++ b/tests/babel/others/absolute.test.ts
@@ -329,6 +329,42 @@ function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: 'JSX mapped from object references including optional chaining',
+    input: `
+function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div key={index} className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    output: `function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div
+          key={index}
+          className="lorem ipsum dolor sit amet consectetur adipiscing elit
+            proin ex massa hendrerit eu posuere eu volutpat id neque
+            pellentesque"
+        >
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/babel/others/relative.test.ts
+++ b/tests/babel/others/relative.test.ts
@@ -324,6 +324,41 @@ function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: 'JSX mapped from object references including optional chaining',
+    input: `
+function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div key={index} className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    output: `function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div
+          key={index}
+          className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+            eu posuere eu volutpat id neque pellentesque"
+        >
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/absolute.test.ts
+++ b/tests/typescript/others/absolute.test.ts
@@ -329,6 +329,42 @@ function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: 'JSX mapped from object references including optional chaining',
+    input: `
+function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div key={index} className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    output: `function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div
+          key={index}
+          className="lorem ipsum dolor sit amet consectetur adipiscing elit
+            proin ex massa hendrerit eu posuere eu volutpat id neque
+            pellentesque"
+        >
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);

--- a/tests/typescript/others/relative.test.ts
+++ b/tests/typescript/others/relative.test.ts
@@ -324,6 +324,41 @@ function Foo() {
       printWidth: 80,
     },
   },
+  {
+    name: 'JSX mapped from object references including optional chaining',
+    input: `
+function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div key={index} className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    output: `function Foo() {
+  return (
+    <div>
+      {foo?.data.map((_, index) => (
+        <div
+          key={index}
+          className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit
+            eu posuere eu volutpat id neque pellentesque"
+        >
+          content
+        </div>
+      ))}
+    </div>
+  );
+}
+`,
+    options: {
+      printWidth: 80,
+    },
+  },
 ];
 
 testEach(fixtures, options);


### PR DESCRIPTION
```javascript
// Input
function Foo() {
  return (
    <div>
      {foo?.data.map((_, index) => (
        <div key={index} className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque">
          content
        </div>
      ))}
    </div>
  );
}

// prettier-plugin-classnames 0.8.0
function Foo() {
  return (
    <div>
      {foo?.data.map((_, index) => (
        <div
          key={index}
          className="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere eu volutpat id neque pellentesque"
        >
          content
        </div>
      ))}
    </div>
  );
}

// prettier-plugin-classnames 0.8.1
function Foo() {
  return (
    <div>
      {foo?.data.map((_, index) => (
        <div
          key={index}
          className="lorem ipsum dolor sit amet consectetur adipiscing elit
            proin ex massa hendrerit eu posuere eu volutpat id neque
            pellentesque"
        >
          content
        </div>
      ))}
    </div>
  );
}
```