### PR TITLE
Support angular control flow blocks

### DIFF
--- a/src/core-parts/finder.ts
+++ b/src/core-parts/finder.ts
@@ -2082,12 +2082,13 @@ export function findTargetClassNameNodesForAngular(
     let recursiveProps: string[] = [];
 
     switch (node.type) {
-      case 'element': {
-        recursiveProps = ['attrs', 'children'];
-        break;
-      }
+      case 'angularControlFlowBlock':
       case 'root': {
         recursiveProps = ['children'];
+        break;
+      }
+      case 'element': {
+        recursiveProps = ['attrs', 'children'];
         break;
       }
       default: {

--- a/tests/angular/issue-117/__snapshots__/absolute.test.ts.snap
+++ b/tests/angular/issue-117/__snapshots__/absolute.test.ts.snap
@@ -1,0 +1,139 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) @defer block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere"
+  ></div>
+} @placeholder {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere"
+  ></div>
+} @loading {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere"
+  ></div>
+} @error {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere"
+  ></div>
+}
+"
+`;
+
+exports[`'(2) @defer block with triggers and pa…' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer (on timer(500ms); prefetch on idle) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @placeholder (minimum 500ms) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @loading (after 100ms; minimum 1s) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @error {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(3) @for block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@for (item of items; track item.name) {
+  <div
+    [className]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @empty {
+  <div
+    [className]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(4) @if block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@if (a > b) {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @else if (b > a) {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @else {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing
+      elit proin ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(5) @switch block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@switch (condition) {
+  @case (caseA) {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+  @case (caseB) {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+  @default {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing
+        elit proin ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+}
+"
+`;

--- a/tests/angular/issue-117/__snapshots__/relative.test.ts.snap
+++ b/tests/angular/issue-117/__snapshots__/relative.test.ts.snap
@@ -1,0 +1,139 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`'(1) @defer block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere"
+  ></div>
+} @placeholder {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere"
+  ></div>
+} @loading {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere"
+  ></div>
+} @error {
+  <div
+    class="lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere"
+  ></div>
+}
+"
+`;
+
+exports[`'(2) @defer block with triggers and pa…' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer (on timer(500ms); prefetch on idle) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @placeholder (minimum 500ms) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @loading (after 100ms; minimum 1s) {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @error {
+  <div
+    [class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(3) @for block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@for (item of items; track item.name) {
+  <div
+    [className]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @empty {
+  <div
+    [className]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(4) @if block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@if (a > b) {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @else if (b > a) {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+} @else {
+  <div
+    [attr.class]="
+      'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+      ex massa hendrerit eu posuere'
+    "
+  ></div>
+}
+"
+`;
+
+exports[`'(5) @switch block' > expectation 1`] = `
+"<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@switch (condition) {
+  @case (caseA) {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+  @case (caseB) {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+  @default {
+    <div
+      [ngClass]="
+        'lorem ipsum dolor sit amet consectetur adipiscing elit proin
+        ex massa hendrerit eu posuere'
+      "
+    ></div>
+  }
+}
+"
+`;

--- a/tests/angular/issue-117/absolute.test.ts
+++ b/tests/angular/issue-117/absolute.test.ts
@@ -1,0 +1,12 @@
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { baseOptions } from '../../settings';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  endingPosition: 'absolute',
+};
+
+testSnapshotEach(fixtures, options);

--- a/tests/angular/issue-117/fixtures.ts
+++ b/tests/angular/issue-117/fixtures.ts
@@ -1,0 +1,90 @@
+import type { Fixture } from '../../settings';
+
+export const fixtures: Omit<Fixture, 'output'>[] = [
+  {
+    name: '(1) @defer block',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer {
+  <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere"></div>
+} @placeholder {
+  <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere"></div>
+} @loading {
+  <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere"></div>
+} @error {
+  <div class="lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere"></div>
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(2) @defer block with triggers and parameters',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@defer (on timer(500ms); prefetch on idle) {
+  <div [class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @placeholder (minimum 500ms) {
+  <div [class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @loading (after 100ms; minimum 1s) {
+  <div [class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @error {
+  <div [class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(3) @for block',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@for (item of items; track item.name) {
+  <div [className]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @empty {
+  <div [className]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(4) @if block',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@if (a > b) {
+  <div [attr.class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @else if (b > a) {
+  <div [attr.class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+} @else {
+  <div [attr.class]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+  {
+    name: '(5) @switch block',
+    input: `
+<!-- ------------------------------------------------------| printWidth=60 (in snapshot) -->
+@switch (condition) {
+  @case (caseA) {
+    <div [ngClass]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+  }
+  @case (caseB) {
+    <div [ngClass]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+  }
+  @default {
+    <div [ngClass]="'lorem ipsum dolor sit amet consectetur adipiscing elit proin ex massa hendrerit eu posuere'"></div>
+  }
+}
+`,
+    options: {
+      printWidth: 60,
+    },
+  },
+];

--- a/tests/angular/issue-117/relative.test.ts
+++ b/tests/angular/issue-117/relative.test.ts
@@ -1,0 +1,12 @@
+import { thisPlugin, testSnapshotEach } from '../../adaptor';
+import { baseOptions } from '../../settings';
+import { fixtures } from './fixtures';
+
+const options = {
+  ...baseOptions,
+  plugins: [thisPlugin],
+  parser: 'angular',
+  endingPosition: 'relative',
+};
+
+testSnapshotEach(fixtures, options);


### PR DESCRIPTION
This PR closes #117.

Please note that [control flow block syntax is only supported in Prettier 3.1 and later](https://prettier.io/blog/2023/11/13/3.1.0.html#angular).