### PR TITLE
Find the correct parser by searching within the plugin.name property

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -77,7 +77,7 @@ function transformParser(
           .filter(
             (plugin) =>
               // @ts-expect-error: `name` is presumed to be injected internally by Prettier.
-              plugin.name === externalPluginName,
+              plugin.name?.includes(externalPluginName),
           )
           .at(0);
 


### PR DESCRIPTION
Fixes #140 for me.

Also see sister-bug-report and MR in `prettier-plugin-merge` repository: https://github.com/ony3000/prettier-plugin-merge/issues/48